### PR TITLE
[Pretest]: Added the intrioductory path structures of kpm dependencies

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1096,6 +1096,7 @@ func (c *KpmClient) Download(dep *pkg.Dependency, homePath, localPath string) (*
 			downloader.WithSource(dep.Source),
 			downloader.WithLogWriter(c.logWriter),
 			downloader.WithSettings(c.settings),
+			downloader.WithHomePath(c.homePath),
 		))
 		if err != nil {
 			return nil, err

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -599,3 +599,9 @@ func AbsTarPath(tarPath string) (string, error) {
 
 	return absTarPath, nil
 }
+
+func CalculateHash(s string) string {
+    h := sha256.New()
+    h.Write([]byte(s))
+    return fmt.Sprintf("%x", h.Sum(nil))[:16]
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -302,3 +302,19 @@ func TestIsModRelativePath(t *testing.T) {
 	assert.Equal(t, IsModRelativePath("${helloworld:KCL_MOD}/aaa"), true)
 	assert.Equal(t, IsModRelativePath("xxx/xxx/xxx"), false)
 }
+
+func TestCalculateHash(t *testing.T) {
+    testCases := []struct {
+        input    string
+        expected string
+    }{
+        {"test", "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"},
+        {"hello world", "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"},
+        {"", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+    }
+
+    for _, tc := range testCases {
+        result := CalculateHash(tc.input)
+        assert.Equal(t, result, tc.expected[:16], "CalculateHash failed for input: %s", tc.input)
+    }
+}


### PR DESCRIPTION


#### 1. Does this PR affect any open issues?(Y/N) and add issue references (related to #384 ):

- [ ] N
- [x] Y 
Related to #384 

#### 2. What is the scope of this PR (e.g. component or file name):

pkg/downloader/downloader.go
pkg/client/client.go
pkg/utils/utils.go
pkg/utils/utils_test.go


#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

This PR implements a new directory structure for storing KCL third-party dependencies, enhancing organization and reducing conflicts. It updates the GitDownloader and OciDownloader to use this new structure

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [ ] N
- [x] Y 

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other


