### PR TITLE
Sparse checkout - kcl mod add --package 

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1119,6 +1119,7 @@ func (c *KpmClient) Download(dep *pkg.Dependency, homePath, localPath string) (*
 				return nil, err
 			}
 			dep.LocalFullPath = localFullPath
+			dep.Name = c.GetPackage()
 		} else {
 			dep.LocalFullPath = localPath
 		}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -759,7 +759,7 @@ func (c *KpmClient) AddDepWithOpts(kclPkg *pkg.KclPkg, opt *opt.AddOptions) (*pk
 	c.noSumCheck = opt.NoSumCheck
 	kclPkg.NoSumCheck = opt.NoSumCheck
 
-	// 1. get the name and version of the repository from the input arguments.
+	// 1. get the name and version of the repository/package from the input arguments.
 	d, err := pkg.ParseOpt(&opt.RegistryOpts)
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/cmd_add.go
+++ b/pkg/cmd/cmd_add.go
@@ -45,6 +45,10 @@ func NewAddCmd(kpmcli *client.KpmClient) *cli.Command {
 				Name:  "rename",
 				Usage: "rename the package name in kcl.mod.lock",
 			},
+			&cli.StringSliceFlag{
+				Name:  "package",
+				Usage: "package name to use in case of git",
+			},
 		},
 
 		Action: func(c *cli.Context) error {
@@ -92,6 +96,10 @@ func KpmAdd(c *cli.Context, kpmcli *client.KpmClient) error {
 	addOpts, err := parseAddOptions(c, kpmcli, globalPkgPath)
 	if err != nil {
 		return err
+	}
+
+	if addOpts.RegistryOpts.Git.Package != "" {
+		kpmcli.SetPackage(addOpts.RegistryOpts.Git.Package)
 	}
 
 	if addOpts.RegistryOpts.Local != nil {
@@ -198,6 +206,12 @@ func parseGitRegistryOptions(c *cli.Context) (*opt.RegistryOptions, *reporter.Kp
 		return nil, err
 	}
 
+	gitPackage, err := onlyOnceOption(c, "package")
+
+	if err != (*reporter.KpmEvent)(nil) {
+		return nil, err
+	}
+
 	if gitUrl == "" {
 		return nil, reporter.NewErrorEvent(reporter.InvalidGitUrl, fmt.Errorf("the argument 'git' is required"))
 	}
@@ -208,9 +222,10 @@ func parseGitRegistryOptions(c *cli.Context) (*opt.RegistryOptions, *reporter.Kp
 
 	return &opt.RegistryOptions{
 		Git: &opt.GitOptions{
-			Url:    gitUrl,
-			Tag:    gitTag,
-			Commit: gitCommit,
+			Url:     gitUrl,
+			Tag:     gitTag,
+			Commit:  gitCommit,
+			Package: gitPackage,
 		},
 	}, nil
 }

--- a/pkg/downloader/source.go
+++ b/pkg/downloader/source.go
@@ -39,6 +39,7 @@ type Git struct {
 	Commit  string `toml:"commit,omitempty"`
 	Tag     string `toml:"git_tag,omitempty"`
 	Version string `toml:"version,omitempty"`
+	Package string `toml:"package,omitempty"`
 }
 
 type Registry struct {

--- a/pkg/downloader/toml.go
+++ b/pkg/downloader/toml.go
@@ -69,6 +69,7 @@ const TAG_PATTERN = "tag = \"%s\""
 const GIT_COMMIT_PATTERN = "commit = \"%s\""
 const GIT_BRANCH_PATTERN = "branch = \"%s\""
 const VERSION_PATTERN = "version = \"%s\""
+const GIT_PACKAGE = "package = \"%s\""
 const SEPARATOR = ", "
 
 func (git *Git) MarshalTOML() string {
@@ -94,6 +95,12 @@ func (git *Git) MarshalTOML() string {
 		sb.WriteString(SEPARATOR)
 		sb.WriteString(fmt.Sprintf(VERSION_PATTERN, git.Version))
 	}
+
+	if len(git.Package) != 0 {
+		sb.WriteString(SEPARATOR)
+		sb.WriteString(fmt.Sprintf(GIT_PACKAGE, git.Package))
+	}
+
 	return sb.String()
 }
 
@@ -175,6 +182,7 @@ const GIT_URL_FLAG = "git"
 const TAG_FLAG = "tag"
 const GIT_COMMIT_FLAG = "commit"
 const GIT_BRANCH_FLAG = "branch"
+const GIT_PACKAGE_FLAG = "package"
 
 func (git *Git) UnmarshalModTOML(data interface{}) error {
 	meta, ok := data.(map[string]interface{})
@@ -196,6 +204,10 @@ func (git *Git) UnmarshalModTOML(data interface{}) error {
 
 	if v, ok := meta[GIT_BRANCH_FLAG].(string); ok {
 		git.Branch = v
+	}
+
+	if v, ok := meta[GIT_PACKAGE_FLAG].(string); ok {
+		git.Package = v
 	}
 
 	return nil

--- a/pkg/opt/opt.go
+++ b/pkg/opt/opt.go
@@ -378,10 +378,11 @@ func ParseLocalPathOptions(localPath string) (*LocalOptions, *reporter.KpmEvent)
 }
 
 type GitOptions struct {
-	Url    string
-	Branch string
-	Commit string
-	Tag    string
+	Url     string
+	Branch  string
+	Commit  string
+	Tag     string
+	Package string
 }
 
 func (opts *GitOptions) Validate() error {

--- a/pkg/package/modfile.go
+++ b/pkg/package/modfile.go
@@ -482,10 +482,11 @@ func (deps *Dependencies) loadLockFile(filepath string) error {
 func ParseOpt(opt *opt.RegistryOptions) (*Dependency, error) {
 	if opt.Git != nil {
 		gitSource := downloader.Git{
-			Url:    opt.Git.Url,
-			Branch: opt.Git.Branch,
-			Commit: opt.Git.Commit,
-			Tag:    opt.Git.Tag,
+			Url:     opt.Git.Url,
+			Branch:  opt.Git.Branch,
+			Commit:  opt.Git.Commit,
+			Tag:     opt.Git.Tag,
+			Package: opt.Git.Package,
 		}
 
 		gitRef, err := gitSource.GetValidGitReference()

--- a/pkg/package/modfile.go
+++ b/pkg/package/modfile.go
@@ -567,18 +567,29 @@ func ParseOpt(opt *opt.RegistryOptions) (*Dependency, error) {
 const PKG_NAME_PATTERN = "%s_%s"
 
 // ParseRepoFullNameFromGitSource will extract the kcl package name from the git url.
+// If the package flag is passed then it will be used as the package name.
 func ParseRepoFullNameFromGitSource(gitSrc downloader.Git) (string, error) {
 	ref, err := gitSrc.GetValidGitReference()
 	if err != nil {
 		return "", err
 	}
 	if len(ref) != 0 {
+		if len(gitSrc.Package) != 0 {
+			return fmt.Sprintf(PKG_NAME_PATTERN, gitSrc.Package, ref), nil
+		}
 		return fmt.Sprintf(PKG_NAME_PATTERN, utils.ParseRepoNameFromGitUrl(gitSrc.Url), ref), nil
+	}
+	if len(gitSrc.Package) != 0 {
+		return gitSrc.Package, nil
 	}
 	return utils.ParseRepoNameFromGitUrl(gitSrc.Url), nil
 }
 
 // ParseRepoNameFromGitSource will extract the kcl package name from the git url.
+// If the package flag is passed then it will be used
 func ParseRepoNameFromGitSource(gitSrc downloader.Git) string {
+	if gitSrc.Package != "" {
+		return gitSrc.Package
+	}
 	return utils.ParseRepoNameFromGitUrl(gitSrc.Url)
 }


### PR DESCRIPTION
<!-- Thank you for contributing to KCL!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kcl-lang.io/docs/community/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kcl-lang/kcl/src/parser 
-->

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

This PR adds a functionality that allows to add a single package in the dependency incase the repo contains multiple of them. It does this as follows: 

1. `kcl mod add --git <url> --commit <hash> --package <package_name>` (done)
    
After running this command, KPM will download the whole repo (also works if there is no kcl.mod in the root) and specifies package in the kcl.mod file. It changes the full_name, name and other similar variables in kcl.mod.lock and kcl.mod as per the package name (it doesn't uses the repo name if package flag is there). 

2. `kcl mod run`  (In progress)

This command will first checkout the directory which contains the package by running a recursive function. It will then do all the usual kcl compilation based on that directory. 
    
#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [ ] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
