### PR TITLE
[WIP]: Extend gitDownloader to support new cache structure

### DIFF
--- a/pkg/downloader/downloader_test.go
+++ b/pkg/downloader/downloader_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+	"kcl-lang.io/kpm/pkg/utils"
 )
 
 const testDataDir = "test_data"
@@ -67,4 +68,97 @@ func TestOciDownloader(t *testing.T) {
 	))
 
 	assert.Equal(t, err, nil)
+}
+
+func TestGitDownloader(t *testing.T) {
+	// Create temporary directories for testing
+	gitTestDir := getTestDir("test_git")
+	if err := os.MkdirAll(gitTestDir, os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.RemoveAll(gitTestDir)
+	}()
+
+	cacheTestDir := getTestDir("test_cache")
+	if err := os.MkdirAll(cacheTestDir, os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.RemoveAll(cacheTestDir)
+	}()
+
+	// Test 1: Normal clone without bare
+	t.Run("NormalCloneWithoutBare", func(t *testing.T) {
+		gitDownloader := GitDownloader{}
+		err := gitDownloader.Download(*NewDownloadOptions(
+			WithSource(Source{
+				Git: &Git{
+					Url:    "https://github.com/kcl-lang/flask-demo-kcl-manifests.git",
+					Commit: "ade147b",
+				},
+			}),
+			WithLocalPath(gitTestDir), // Use the temp directory for clone
+		))
+
+		assert.Equal(t, err, nil)
+	})
+
+	// Test 2: Caching enabled and cloning to non-existing cache path as bare repo
+	t.Run("CachingEnabledCloneToNonExistingCachePath", func(t *testing.T) {
+		gitDownloader := GitDownloader{}
+		err := gitDownloader.Download(*NewDownloadOptions(
+			WithSource(Source{
+				Git: &Git{
+					Url:    "https://github.com/kcl-lang/flask-demo-kcl-manifests.git",
+					Commit: "ade147b",
+				},
+			}),
+			WithLocalPath(gitTestDir),   // Use the temp directory for clone
+			WithCachePath(cacheTestDir), // Set cache path
+			WithEnableCache(true),       // Enable caching
+		))
+
+		assert.Equal(t, err, nil)
+
+		// Verify that the cache path contains a bare repo
+		assert.Assert(t, utils.DirExists(cacheTestDir), "Cache directory does not exist")
+	})
+
+	// Test 3: Caching enabled and cache directory already exists, perform checkout from bare cached repo
+	t.Run("CachingEnabledCheckoutFromExistingCache", func(t *testing.T) {
+		gitDownloader := GitDownloader{}
+		// Pre-clone to cache directory first
+		err := gitDownloader.Download(*NewDownloadOptions(
+			WithSource(Source{
+				Git: &Git{
+					Url:    "https://github.com/kcl-lang/flask-demo-kcl-manifests.git",
+					Commit: "ade147b",
+				},
+			}),
+			WithLocalPath(gitTestDir),   // Use the temp directory for clone
+			WithCachePath(cacheTestDir), // Set cache path
+			WithEnableCache(true),       // Enable caching
+		))
+
+		assert.Equal(t, err, nil)
+
+		// Now try to download again to test checkout from the cache
+		err = gitDownloader.Download(*NewDownloadOptions(
+			WithSource(Source{
+				Git: &Git{
+					Url:    "https://github.com/kcl-lang/flask-demo-kcl-manifests.git",
+					Commit: "ade147b",
+				},
+			}),
+			WithLocalPath(gitTestDir),   // Use the same temp directory
+			WithCachePath(cacheTestDir), // Set the same cache path
+			WithEnableCache(true),       // Keep caching enabled
+		))
+
+		assert.Equal(t, err, nil)
+
+		// Optionally verify the contents of the checkout
+		// Check for specific files or directories that should exist after checkout
+	})
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -4,8 +4,10 @@ import (
 	"archive/tar"
 	"bufio"
 	"compress/gzip"
+	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	goerrors "errors"
 	"fmt"
 	"io"
@@ -662,4 +664,11 @@ func MoveOrCopy(src, dest string) error {
 		}
 	}
 	return nil
+}
+
+// generateHash takes a string (in this case, the Git URL) and returns a SHA-1 hash.
+func GenerateHash(input string) string {
+	hash := sha1.New()
+	hash.Write([]byte(input))
+	return hex.EncodeToString(hash.Sum(nil))
 }


### PR DESCRIPTION
<!-- Thank you for contributing to KCL!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kcl-lang.io/docs/community/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

fix #384 

#### 2. What is the scope of this PR (e.g. component or file name):

pkg/downloader/downloader.go
pkg/downloader/downloader_test.go
pkg/utils/utils.go

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [ ] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

We already have completed `CloneWithOpts` to support bare cloning , in this PR I have extended the `gitDownloader` to clone the dependency as bare repo to the cache path. 