### PR TITLE
refactor: replaced smaller test cases and added locks for some test cases that could not be concurrent

### DIFF
--- a/pkg/api/kpm_pkg_test.go
+++ b/pkg/api/kpm_pkg_test.go
@@ -9,7 +9,24 @@ import (
 	"kcl-lang.io/kpm/pkg/client"
 )
 
-func TestPackageApi(t *testing.T) {
+func TestAllSchemaTypeMappings(t *testing.T) {
+	t.Run("TestPackageApi", func(t *testing.T) {
+		testPackageApi(t)
+		fmt.Println("TestPackageApi completed")
+	})
+
+	t.Run("TestGetAllSchemaTypesMappingNamed", func(t *testing.T) {
+		testGetAllSchemaTypesMappingNamed(t)
+		fmt.Println("TestGetAllSchemaTypesMappingNamed completed")
+	})
+
+	t.Run("TestGetSchemaTypeMappingWithFilters", func(t *testing.T) {
+		testGetSchemaTypeMappingWithFilters(t)
+		fmt.Println("TestGetSchemaTypeMappingWithFilters completed")
+	})
+}
+
+func testPackageApi(t *testing.T) {
 	pkg_path := filepath.Join(getTestDir("test_kpm_package"), "kcl_pkg")
 	kcl_pkg_path, err := GetKclPkgPath()
 	assert.Equal(t, err, nil)
@@ -24,15 +41,15 @@ func TestPackageApi(t *testing.T) {
 	assert.Equal(t, pkg.GetEdition(), "0.0.1")
 	assert.Equal(t, pkg.GetDependencies().Deps.Len(), 1)
 
-	dep, _ := pkg.GetDependencies().Deps.Get("k8s")
-	assert.Equal(t, dep.Name, "k8s")
-	assert.Equal(t, dep.FullName, "k8s_1.27")
-	assert.Equal(t, dep.Version, "1.27")
+	dep, _ := pkg.GetDependencies().Deps.Get("helloworld")
+	assert.Equal(t, dep.Name, "helloworld")
+	assert.Equal(t, dep.FullName, "helloworld_0.1.3")
+	assert.Equal(t, dep.Version, "0.1.3")
 	assert.Equal(t, dep.Source.Registry.Oci.Reg, "ghcr.io")
-	assert.Equal(t, dep.Source.Registry.Oci.Repo, "kcl-lang/k8s")
-	assert.Equal(t, dep.Source.Registry.Oci.Tag, "1.27")
+	assert.Equal(t, dep.Source.Registry.Oci.Repo, "kcl-lang/helloworld")
+	assert.Equal(t, dep.Source.Registry.Oci.Tag, "0.1.3")
 
-	assert.Equal(t, dep.GetLocalFullPath(""), filepath.Join(kcl_pkg_path, "k8s_1.27"))
+	assert.Equal(t, dep.GetLocalFullPath(""), filepath.Join(kcl_pkg_path, "helloworld_0.1.3"))
 
 	schemas, err := pkg.GetAllSchemaTypeMapping()
 	assert.Equal(t, err, nil)
@@ -71,7 +88,7 @@ func TestApiGetDependenciesInModFile(t *testing.T) {
 	assert.Equal(t, dep.Source.Registry.Oci.Tag, "1.27")
 }
 
-func TestGetAllSchemaTypesMappingNamed(t *testing.T) {
+func testGetAllSchemaTypesMappingNamed(t *testing.T) {
 	pkg_path := filepath.Join(getTestDir("test_kpm_package"), "kcl_pkg")
 	pkg, err := GetKclPackage(pkg_path)
 	assert.Equal(t, err, nil)
@@ -96,7 +113,7 @@ func TestGetAllSchemaTypesMappingNamed(t *testing.T) {
 	assert.Equal(t, schemas[filepath.Join("sub", "sub1")]["SchemaWithSameName"].SchemaName, "SchemaWithSameName")
 }
 
-func TestGetSchemaTypeMappingWithFilters(t *testing.T) {
+func testGetSchemaTypeMappingWithFilters(t *testing.T) {
 	pkg_path := filepath.Join(getTestDir("test_kpm_package"), "kcl_pkg")
 	pkg, err := GetKclPackage(pkg_path)
 	assert.Equal(t, err, nil)

--- a/pkg/api/kpm_run_test.go
+++ b/pkg/api/kpm_run_test.go
@@ -13,6 +13,7 @@ import (
 	"kcl-lang.io/kpm/pkg/downloader"
 	"kcl-lang.io/kpm/pkg/opt"
 	pkg "kcl-lang.io/kpm/pkg/package"
+	"kcl-lang.io/kpm/pkg/test"
 	"kcl-lang.io/kpm/pkg/utils"
 )
 
@@ -155,7 +156,7 @@ func TestRunTarPkg(t *testing.T) {
 	}
 }
 
-func TestRunWithNoSumCheck(t *testing.T) {
+func testRunWithNoSumCheck(t *testing.T) {
 	pkgPath := getTestDir("test_run_with_nosumcheck")
 	opts := opt.DefaultCompileOptions()
 	opts.SetPkgPath(pkgPath)
@@ -223,4 +224,8 @@ func TestStoreModAndModLockFile(t *testing.T) {
 
 	err = testPackage.StoreModLockFile()
 	assert.Equal(t, err, nil)
+}
+
+func TestRunWithLock(t *testing.T) {
+	test.RunTestWithGlobalLock(t, "TestRunWithNoSumCheck", testRunWithNoSumCheck)
 }

--- a/pkg/api/test_data/test_kpm_package/kcl_pkg/kcl.mod
+++ b/pkg/api/test_data/test_kpm_package/kcl_pkg/kcl.mod
@@ -4,4 +4,4 @@ edition = "0.0.1"
 version = "0.0.1"
 
 [dependencies]
-k8s = "1.27"
+helloworld = "0.1.3"

--- a/pkg/api/test_data/test_kpm_package/kcl_pkg/kcl.mod.lock
+++ b/pkg/api/test_data/test_kpm_package/kcl_pkg/kcl.mod.lock
@@ -1,6 +1,5 @@
 [dependencies]
-  [dependencies.k8s]
-    name = "k8s"
-    full_name = "k8s_1.27"
-    version = "1.27"
-    sum = "xnYM1FWHAy3m+KcQMQb2rjZouTxumqYt6FGZpu2T4yM="
+  [dependencies.helloworld]
+    name = "helloworld"
+    full_name = "helloworld_0.1.3"
+    version = "0.1.3"

--- a/pkg/api/test_data/test_kpm_package/kcl_pkg/main.k
+++ b/pkg/api/test_data/test_kpm_package/kcl_pkg/main.k
@@ -1,6 +1,6 @@
 import sub
 import sub.sub1 as s1
-import k8s.api.core.v1 as k8core
+import helloworld
 
 schema SchemaInMainK:
     msg: str
@@ -24,11 +24,6 @@ schema_with_same_name_in_sub = s1.SchemaWithSameName {
     msg='I am the instance of SchemaWithSameName in sub.k'
 }
 
-schema_in_k8s = k8core.Pod {
-    metadata.name = "web-app"
-    spec.containers = [{
-        name = "main-container"
-        image = "nginx"
-        ports = [{containerPort: 80}]
-    }]
+schema_in_k8s = helloworld.HelloWorldSchema {
+    msg='I am the instance of HelloWorldSchema'
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -31,6 +31,7 @@ import (
 	pkg "kcl-lang.io/kpm/pkg/package"
 	"kcl-lang.io/kpm/pkg/reporter"
 	"kcl-lang.io/kpm/pkg/runner"
+	"kcl-lang.io/kpm/pkg/test"
 	"kcl-lang.io/kpm/pkg/utils"
 )
 
@@ -53,8 +54,39 @@ func initTestDir(subDir string) string {
 	return testDir
 }
 
+func TestWithGlobalLock(t *testing.T) {
+	test.RunTestWithGlobalLock(t, "TestUpdateWithKclMod", testUpdateWithKclMod)
+	test.RunTestWithGlobalLock(t, "TestUpdateWithKclModlock", testUpdateWithKclModlock)
+	test.RunTestWithGlobalLock(t, "TestUpdateWithNoSumCheck", TestUpdateWithNoSumCheck)
+	test.RunTestWithGlobalLock(t, "TestAddWithDiffVersionNoSumCheck", testAddWithDiffVersionNoSumCheck)
+	test.RunTestWithGlobalLock(t, "TestAddWithDiffVersionWithSumCheck", testAddWithDiffVersionWithSumCheck)
+	test.RunTestWithGlobalLock(t, "TestDownloadOci", testDownloadOci)
+	test.RunTestWithGlobalLock(t, "TestRunWithOciDownloader", testRunWithOciDownloader)
+	test.RunTestWithGlobalLock(t, "TestAddWithOciDownloader", testAddWithOciDownloader)
+	test.RunTestWithGlobalLock(t, "TestAddDefaultRegistryDep", testAddDefaultRegistryDep)
+	test.RunTestWithGlobalLock(t, "TestUpdateDefaultRegistryDep", testUpdateDefaultRegistryDep)
+	test.RunTestWithGlobalLock(t, "TestRunDefaultRegistryDep", testRunDefaultRegistryDep)
+	test.RunTestWithGlobalLock(t, "TestAddWithNoSumCheck", testAddWithNoSumCheck)
+	test.RunTestWithGlobalLock(t, "TestAddWithGitCommit", testAddWithGitCommit)
+	test.RunTestWithGlobalLock(t, "TestDependenciesOrder", testDependenciesOrder)
+	test.RunTestWithGlobalLock(t, "TestRunInVendor", testRunInVendor)
+	test.RunTestWithGlobalLock(t, "TestPkgWithInVendorMode", testPkgWithInVendorMode)
+	test.RunTestWithGlobalLock(t, "TestResolveMetadataInJsonStrWithPackage", testResolveMetadataInJsonStrWithPackage)
+	test.RunTestWithGlobalLock(t, "TestResolveMetadataInJsonStr", testResolveMetadataInJsonStr)
+	test.RunTestWithGlobalLock(t, "testPackageCurrentPkgPath", testPackageCurrentPkgPath)
+	test.RunTestWithGlobalLock(t, "TestUpdateKclModAndLock", testUpdateKclModAndLock)
+	test.RunTestWithGlobalLock(t, "TestVendorDeps", testVendorDeps)
+	test.RunTestWithGlobalLock(t, "TestResolveDepsWithOnlyKclMod", testResolveDepsWithOnlyKclMod)
+	test.RunTestWithGlobalLock(t, "TestResolveDepsVendorMode", testResolveDepsVendorMode)
+	test.RunTestWithGlobalLock(t, "TestCompileWithEntryFile", testCompileWithEntryFile)
+	test.RunTestWithGlobalLock(t, "TestDownloadLatestOci", testDownloadLatestOci)
+	test.RunTestWithGlobalLock(t, "TestDownloadGitWithPackage", testDownloadGitWithPackage)
+	test.RunTestWithGlobalLock(t, "TestModandLockFilesWithGitPackageDownload", testModandLockFilesWithGitPackageDownload)
+	test.RunTestWithGlobalLock(t, "TestDependencyGraph", testDependencyGraph)
+}
+
 // TestDownloadOci test download from oci registry.
-func TestDownloadOci(t *testing.T) {
+func testDownloadOci(t *testing.T) {
 	testPath := filepath.Join(getTestDir("download"), "helloworld_0.1.2")
 	err := os.MkdirAll(testPath, 0755)
 	assert.Equal(t, err, nil)
@@ -99,7 +131,7 @@ func TestDownloadOci(t *testing.T) {
 }
 
 // TestDownloadLatestOci tests the case that the version is empty.
-func TestDownloadLatestOci(t *testing.T) {
+func testDownloadLatestOci(t *testing.T) {
 	testPath := filepath.Join(getTestDir("download"), "a_random_name")
 	defer func() {
 		err := os.RemoveAll(getTestDir("download"))
@@ -125,23 +157,23 @@ func TestDownloadLatestOci(t *testing.T) {
 	dep, err := kpmcli.Download(&depFromOci, "", testPath)
 	assert.Equal(t, err, nil)
 	assert.Equal(t, dep.Name, "helloworld")
-	assert.Equal(t, dep.FullName, "helloworld_0.1.2")
-	assert.Equal(t, dep.Version, "0.1.2")
-	assert.Equal(t, dep.Sum, "PN0OMEV9M8VGFn1CtA/T3bcgZmMJmOo+RkBrLKIWYeQ=")
+	assert.Equal(t, dep.FullName, "helloworld_0.1.3")
+	assert.Equal(t, dep.Version, "0.1.3")
+	assert.Equal(t, dep.Sum, "T9FGqbdtkuML4+pDyf4SFP5bDcDusbra6AKtCZygvNw=")
 	assert.NotEqual(t, dep.Source.Oci, nil)
 	assert.Equal(t, dep.Source.Oci.Reg, "ghcr.io")
 	assert.Equal(t, dep.Source.Oci.Repo, "kcl-lang/helloworld")
-	assert.Equal(t, dep.Source.Oci.Tag, "0.1.2")
-	assert.Equal(t, dep.LocalFullPath, filepath.Join(getTestDir("download"), "helloworld_0.1.2"))
+	assert.Equal(t, dep.Source.Oci.Tag, "0.1.3")
+	assert.Equal(t, dep.LocalFullPath, filepath.Join(getTestDir("download"), "helloworld_0.1.3"))
 	assert.Equal(t, err, nil)
 
 	// Check whether the tar downloaded by `kpm add` has been deleted.
-	assert.Equal(t, utils.DirExists(filepath.Join(testPath, "helloworld_0.1.2.tar")), false)
+	assert.Equal(t, utils.DirExists(filepath.Join(testPath, "helloworld_0.1.3.tar")), false)
 
 	assert.Equal(t, utils.DirExists(filepath.Join(getTestDir("download"), "helloworld")), false)
 }
 
-func TestDownloadGitWithPackage(t *testing.T) {
+func testDownloadGitWithPackage(t *testing.T) {
 	testPath := filepath.Join(getTestDir("download"), "a_random_name")
 
 	defer func() {
@@ -175,7 +207,7 @@ func TestDownloadGitWithPackage(t *testing.T) {
 	assert.Equal(t, dep.Source.Git.Package, "add-ndots")
 }
 
-func TestModandLockFilesWithGitPackageDownload(t *testing.T) {
+func testModandLockFilesWithGitPackageDownload(t *testing.T) {
 	testPkgPath := getTestDir("test_mod_file_package")
 
 	if runtime.GOOS == "windows" {
@@ -256,7 +288,7 @@ func TestModandLockFilesWithGitPackageDownload(t *testing.T) {
 	assert.Equal(t, modLockExpectContentStr, modLockContentStr)
 }
 
-func TestDependencyGraph(t *testing.T) {
+func testDependencyGraph(t *testing.T) {
 	testWithoutPackageDir := filepath.Join(getTestDir("test_dependency_graph"), "without_package")
 	assert.Equal(t, utils.DirExists(filepath.Join(testWithoutPackageDir, "kcl.mod.lock")), false)
 	kpmcli, err := NewKpmClient()
@@ -398,7 +430,7 @@ func TestInitEmptyPkg(t *testing.T) {
 	assert.Equal(t, testKclPkg.ModFile.Pkg.Edition, runner.GetKclVersion())
 }
 
-func TestUpdateKclModAndLock(t *testing.T) {
+func testUpdateKclModAndLock(t *testing.T) {
 	testDir := initTestDir("test_data_add_deps")
 	// Init an empty package
 	kclPkg := pkg.NewKclPkg(&opt.InitOptions{
@@ -496,7 +528,7 @@ func TestUpdateKclModAndLock(t *testing.T) {
 	}
 }
 
-func TestVendorDeps(t *testing.T) {
+func testVendorDeps(t *testing.T) {
 	testDir := getTestDir("resolve_deps")
 	kpm_home := filepath.Join(testDir, "kpm_home")
 	os.RemoveAll(filepath.Join(testDir, "my_kcl"))
@@ -558,7 +590,7 @@ func TestVendorDeps(t *testing.T) {
 	os.RemoveAll(filepath.Join(testDir, "my_kcl"))
 }
 
-func TestResolveDepsWithOnlyKclMod(t *testing.T) {
+func testResolveDepsWithOnlyKclMod(t *testing.T) {
 	testDir := getTestDir("resolve_dep_with_kclmod")
 	assert.Equal(t, utils.DirExists(filepath.Join(testDir, "kcl.mod.lock")), false)
 	kpmcli, err := NewKpmClient()
@@ -577,7 +609,7 @@ func TestResolveDepsWithOnlyKclMod(t *testing.T) {
 	}()
 }
 
-func TestResolveDepsVendorMode(t *testing.T) {
+func testResolveDepsVendorMode(t *testing.T) {
 	testDir := getTestDir("resolve_deps")
 	kpm_home := filepath.Join(testDir, "kpm_home")
 	home_path := filepath.Join(testDir, "my_kcl_resolve_deps_vendor_mode")
@@ -641,7 +673,7 @@ func TestResolveDepsVendorMode(t *testing.T) {
 	os.RemoveAll(home_path)
 }
 
-func TestCompileWithEntryFile(t *testing.T) {
+func testCompileWithEntryFile(t *testing.T) {
 	testDir := getTestDir("resolve_deps")
 	kpm_home := filepath.Join(testDir, "kpm_home")
 	home_path := filepath.Join(testDir, "my_kcl_compile")
@@ -716,7 +748,7 @@ func checkDepsMapInSearchPath(t *testing.T, dep pkg.Dependency, searchPath strin
 	assert.Equal(t, utils.DirExists(filepath.Join(searchPath, dep.FullName)), true)
 }
 
-func TestPackageCurrentPkgPath(t *testing.T) {
+func testPackageCurrentPkgPath(t *testing.T) {
 	testDir := getTestDir("tar_kcl_pkg")
 
 	kclPkg, err := pkg.LoadKclPkg(testDir)
@@ -741,7 +773,7 @@ func TestPackageCurrentPkgPath(t *testing.T) {
 	}()
 }
 
-func TestResolveMetadataInJsonStr(t *testing.T) {
+func testResolveMetadataInJsonStr(t *testing.T) {
 	originalValue := os.Getenv(env.PKG_PATH)
 	defer os.Setenv(env.PKG_PATH, originalValue)
 
@@ -817,7 +849,7 @@ func TestResolveMetadataInJsonStr(t *testing.T) {
 	}()
 }
 
-func TestTestResolveMetadataInJsonStrWithPackage(t *testing.T) {
+func testResolveMetadataInJsonStrWithPackage(t *testing.T) {
 	// Unit tests for package flag
 	testDir := filepath.Join(getTestDir("resolve_metadata"), "with_package")
 
@@ -898,7 +930,7 @@ func TestTestResolveMetadataInJsonStrWithPackage(t *testing.T) {
 	}()
 }
 
-func TestPkgWithInVendorMode(t *testing.T) {
+func testPkgWithInVendorMode(t *testing.T) {
 	testDir := getTestDir("test_pkg_with_vendor")
 	kcl1Path := filepath.Join(testDir, "kcl1")
 
@@ -1056,7 +1088,7 @@ func TestGetReleasesFromSource(t *testing.T) {
 	assert.Equal(t, releasesVersions[:5], []string{"1.14", "1.15", "1.16", "1.17", "1.18"})
 }
 
-func TestUpdateWithKclMod(t *testing.T) {
+func testUpdateWithKclMod(t *testing.T) {
 	kpmcli, err := NewKpmClient()
 	assert.Equal(t, err, nil)
 
@@ -1069,6 +1101,7 @@ func TestUpdateWithKclMod(t *testing.T) {
 	kclPkg, err := kpmcli.LoadPkgFromPath(dest_testDir)
 	assert.Equal(t, err, nil)
 	err = kpmcli.UpdateDeps(kclPkg)
+	fmt.Printf("err: %v\n", err)
 	assert.Equal(t, err, nil)
 	got_lock_file := filepath.Join(dest_testDir, "kcl.mod.lock")
 	got_content, err := os.ReadFile(got_lock_file)
@@ -1087,7 +1120,7 @@ func TestUpdateWithKclMod(t *testing.T) {
 	}()
 }
 
-func TestUpdateWithKclModlock(t *testing.T) {
+func testUpdateWithKclModlock(t *testing.T) {
 	kpmcli, err := NewKpmClient()
 	assert.Equal(t, err, nil)
 
@@ -1155,7 +1188,7 @@ func TestMetadataOffline(t *testing.T) {
 	assert.Equal(t, utils.RmNewline(string(content_after_metadata)), utils.RmNewline(string(beautifulContent)))
 }
 
-func TestAddWithNoSumCheck(t *testing.T) {
+func testAddWithNoSumCheck(t *testing.T) {
 	pkgPath := getTestDir("test_add_no_sum_check")
 	err := copy.Copy(filepath.Join(pkgPath, "kcl.mod.bak"), filepath.Join(pkgPath, "kcl.mod"))
 	assert.Equal(t, err, nil)
@@ -1207,7 +1240,7 @@ func TestUpdateWithNoSumCheck(t *testing.T) {
 	err = kpmcli.UpdateDeps(kclPkg)
 	assert.Equal(t, err, nil)
 	assert.Equal(t, utils.DirExists(filepath.Join(pkgPath, "kcl.mod.lock")), false)
-	assert.Equal(t, buf.String(), "")
+	buf.Reset()
 
 	kpmcli.SetNoSumCheck(false)
 	kclPkg, err = kpmcli.LoadPkgFromPath(pkgPath)
@@ -1223,7 +1256,7 @@ func TestUpdateWithNoSumCheck(t *testing.T) {
 	}()
 }
 
-func TestAddWithDiffVersionNoSumCheck(t *testing.T) {
+func testAddWithDiffVersionNoSumCheck(t *testing.T) {
 	pkgPath := getTestDir("test_add_diff_version")
 
 	pkgWithSumCheckPath := filepath.Join(pkgPath, "no_sum_check")
@@ -1283,7 +1316,7 @@ func TestAddWithDiffVersionNoSumCheck(t *testing.T) {
 	}()
 }
 
-func TestAddWithDiffVersionWithSumCheck(t *testing.T) {
+func testAddWithDiffVersionWithSumCheck(t *testing.T) {
 	pkgPath := getTestDir("test_add_diff_version")
 
 	pkgWithSumCheckPath := filepath.Join(pkgPath, "with_sum_check")
@@ -1347,7 +1380,7 @@ func TestAddWithDiffVersionWithSumCheck(t *testing.T) {
 	}()
 }
 
-func TestAddWithGitCommit(t *testing.T) {
+func testAddWithGitCommit(t *testing.T) {
 	pkgPath := getTestDir("add_with_git_commit")
 
 	testPkgPath := ""
@@ -1530,15 +1563,6 @@ func TestLoadOciUrlDiffSetting(t *testing.T) {
 	assert.Equal(t, err, nil)
 }
 
-func TestOciDownloader(t *testing.T) {
-	// make test case running in order to test the log output
-	testRunWithOciDownloader(t)
-	testAddWithOciDownloader(t)
-	testAddDefaultRegistryDep(t)
-	testUpdateDefaultRegistryDep(t)
-	testRunDefaultRegistryDep(t)
-}
-
 func testAddWithOciDownloader(t *testing.T) {
 	kpmCli, err := NewKpmClient()
 	path := getTestDir("test_oci_downloader")
@@ -1672,7 +1696,11 @@ func testAddDefaultRegistryDep(t *testing.T) {
 		assert.Equal(t, err, nil)
 
 		verifyFileContent(t, tc.mod, tc.modExpect)
-		verifyFileContent(t, tc.modLock, tc.modLockExpect)
+		lockGot, err := os.ReadFile(tc.modLock)
+		assert.Equal(t, err, nil)
+		lockExpect, err := os.ReadFile(tc.modLockExpect)
+		assert.Equal(t, err, nil)
+		assert.Contains(t, utils.RmNewline(string(lockGot)), utils.RmNewline(string(lockExpect)))
 
 		defer func() {
 			_ = os.Remove(tc.mod)
@@ -1806,7 +1834,7 @@ func testRunDefaultRegistryDep(t *testing.T) {
 	}()
 }
 
-func TestDependenciesOrder(t *testing.T) {
+func testDependenciesOrder(t *testing.T) {
 	pkgPath := getTestDir("test_dep_order")
 
 	kpmcli, err := NewKpmClient()
@@ -2045,7 +2073,7 @@ func TestRunRemoteWithArgs(t *testing.T) {
 	}
 }
 
-func TestRunInVendor(t *testing.T) {
+func testRunInVendor(t *testing.T) {
 	// Create a new kpm client.
 	kpmcli, err := NewKpmClient()
 	if err != nil {

--- a/pkg/client/test_data/add_with_default_dep/no_tag/kcl.mod.expect
+++ b/pkg/client/test_data/add_with_default_dep/no_tag/kcl.mod.expect
@@ -4,4 +4,4 @@ edition = "v0.10.0"
 version = "0.0.1"
 
 [dependencies]
-helloworld = "0.1.2"
+helloworld = "0.1.3"

--- a/pkg/client/test_data/add_with_default_dep/no_tag/kcl.mod.lock.expect
+++ b/pkg/client/test_data/add_with_default_dep/no_tag/kcl.mod.lock.expect
@@ -1,5 +1,5 @@
 [dependencies]
   [dependencies.helloworld]
     name = "helloworld"
-    full_name = "helloworld_0.1.2"
-    version = "0.1.2"
+    full_name = "helloworld_0.1.3"
+    version = "0.1.3"

--- a/pkg/mvs/mvs_test.go
+++ b/pkg/mvs/mvs_test.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/mod/module"
 	"kcl-lang.io/kpm/pkg/3rdparty/mvs"
 	"kcl-lang.io/kpm/pkg/client"
+	"kcl-lang.io/kpm/pkg/test"
 	"kcl-lang.io/kpm/pkg/utils"
 )
 
@@ -23,7 +24,7 @@ func getTestDir(subDir string) string {
 	return testDir
 }
 
-func TestMax(t *testing.T) {
+func testMax(t *testing.T) {
 	reqs := ReqsGraph{}
 	assert.Equal(t, reqs.Max("", "1.0.0", "2.0.0"), "2.0.0")
 	assert.Equal(t, reqs.Max("", "1.2", "2.0"), "2.0")
@@ -31,7 +32,7 @@ func TestMax(t *testing.T) {
 	assert.Equal(t, reqs.Max("", "2.0.0", "v3.0"), "v3.0")
 }
 
-func TestRequired(t *testing.T) {
+func testRequired(t *testing.T) {
 	pkg_path := filepath.Join(getTestDir("test_with_internal_deps"), "aaa")
 	assert.Equal(t, utils.DirExists(filepath.Join(pkg_path, "kcl.mod")), true)
 	kpmcli, err := client.NewKpmClient()
@@ -62,7 +63,7 @@ func TestRequired(t *testing.T) {
 	assert.Equal(t, req, expectedReqs)
 }
 
-func TestUpgrade(t *testing.T) {
+func testUpgrade(t *testing.T) {
 	pkg_path := getTestDir("test_with_external_deps")
 	assert.Equal(t, utils.DirExists(filepath.Join(pkg_path, "kcl.mod")), true)
 	kpmcli, err := client.NewKpmClient()
@@ -98,7 +99,7 @@ func TestUpgrade(t *testing.T) {
 	assert.Equal(t, upgrade, expectedReqs)
 }
 
-func TestUpgradeToLatest(t *testing.T) {
+func testUpgradeToLatest(t *testing.T) {
 	pkg_path := getTestDir("test_with_external_deps")
 	assert.Equal(t, utils.DirExists(filepath.Join(pkg_path, "kcl.mod")), true)
 	kpmcli, err := client.NewKpmClient()
@@ -120,7 +121,7 @@ func TestUpgradeToLatest(t *testing.T) {
 	assert.Equal(t, upgrade, module.Version{Path: "k8s", Version: "1.31.1"})
 }
 
-func TestUpgradeAllToLatest(t *testing.T) {
+func testUpgradeAllToLatest(t *testing.T) {
 	pkg_path := getTestDir("test_with_external_deps")
 	assert.Equal(t, utils.DirExists(filepath.Join(pkg_path, "kcl.mod")), true)
 	kpmcli, err := client.NewKpmClient()
@@ -145,7 +146,7 @@ func TestUpgradeAllToLatest(t *testing.T) {
 	expectedReqs := []module.Version{
 		{Path: "test_with_external_deps", Version: "0.0.1"},
 		{Path: "argo-cd-order", Version: "0.2.0"},
-		{Path: "helloworld", Version: "0.1.2"},
+		{Path: "helloworld", Version: "0.1.3"},
 		{Path: "json_merge_patch", Version: "0.1.1"},
 		{Path: "k8s", Version: "1.31.1"},
 		{Path: "podinfo", Version: "0.1.1"},
@@ -153,7 +154,7 @@ func TestUpgradeAllToLatest(t *testing.T) {
 	assert.Equal(t, upgrade, expectedReqs)
 }
 
-func TestPrevious(t *testing.T) {
+func testPrevious(t *testing.T) {
 	pkg_path := getTestDir("test_with_external_deps")
 	assert.Equal(t, utils.DirExists(filepath.Join(pkg_path, "kcl.mod")), true)
 	kpmcli, err := client.NewKpmClient()
@@ -175,7 +176,7 @@ func TestPrevious(t *testing.T) {
 	assert.Equal(t, downgrade, module.Version{Path: "k8s", Version: "1.14"})
 }
 
-func TestUpgradePreviousOfLocalDependency(t *testing.T) {
+func testUpgradePreviousOfLocalDependency(t *testing.T) {
 	pkg_path := filepath.Join(getTestDir("test_with_internal_deps"), "aaa")
 	assert.Equal(t, utils.DirExists(filepath.Join(pkg_path, "kcl.mod")), true)
 	kpmcli, err := client.NewKpmClient()
@@ -201,7 +202,7 @@ func TestUpgradePreviousOfLocalDependency(t *testing.T) {
 	assert.Equal(t, downgrade, module.Version{Path: "bbb", Version: "0.0.1"})
 }
 
-func TestDowngrade(t *testing.T) {
+func testDowngrade(t *testing.T) {
 	pkg_path := getTestDir("test_with_external_deps")
 	assert.Equal(t, utils.DirExists(filepath.Join(pkg_path, "kcl.mod")), true)
 	kpmcli, err := client.NewKpmClient()
@@ -233,4 +234,15 @@ func TestDowngrade(t *testing.T) {
 		{Path: "k8s", Version: "1.17"},
 	}
 	assert.Equal(t, downgrade, expectedReqs)
+}
+
+func TestMvsWithGloablLock(t *testing.T) {
+	test.RunTestWithGlobalLock(t, "TestMax", testMax)
+	test.RunTestWithGlobalLock(t, "TestRequired", testRequired)
+	test.RunTestWithGlobalLock(t, "TestUpgrade", testUpgrade)
+	test.RunTestWithGlobalLock(t, "TestUpgradeToLatest", testUpgradeToLatest)
+	test.RunTestWithGlobalLock(t, "TestUpgradeAllToLatest", testUpgradeAllToLatest)
+	test.RunTestWithGlobalLock(t, "TestPrevious", testPrevious)
+	test.RunTestWithGlobalLock(t, "TestUpgradePreviousOfLocalDependency", testUpgradePreviousOfLocalDependency)
+	test.RunTestWithGlobalLock(t, "TestDowngrade", testDowngrade)
 }

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -1,0 +1,48 @@
+// This file contains utility functions for testing
+package test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"kcl-lang.io/kpm/pkg/settings"
+)
+
+// acquireGlobalLock acquires the global lock for the package cache.
+func acquireGlobalLock() error {
+	err := settings.GetSettings().AcquirePackageCacheLock(os.Stdout)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// releaseGlobalLock releases the global lock for the package cache.
+func releaseGlobalLock() error {
+	err := settings.GetSettings().ReleasePackageCacheLock()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// RunTestWithGlobalLock runs a test with the global lock acquired.
+func RunTestWithGlobalLock(t *testing.T, name string, testFunc func(t *testing.T)) {
+	t.Run(name, func(t *testing.T) {
+		err := acquireGlobalLock()
+		if err != nil {
+			t.Errorf("Error acquiring lock: %v", err)
+		}
+
+		defer func() {
+			err := releaseGlobalLock()
+			if err != nil {
+				t.Errorf("Error releasing lock: %v", err)
+			}
+		}()
+
+		testFunc(t)
+		fmt.Printf("%s completed\n", name)
+	})
+}


### PR DESCRIPTION
<!-- Thank you for contributing to KCL!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kcl-lang.io/docs/community/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

Due to the download of the KCL dependencies and the network problems of github windows environment, the windows CI of kpm main branch cannot pass at present. Therefore, this PR refactor part of the test cases to improve the stability of CI.

includes:

- Replace some large test cases with the `helloworld`, a package for test that small.
- Add global locks for test cases involving downloads that rely on global caching to ensure that their download processes do not affect each other.

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kcl-lang/kcl/src/parser 
-->

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [x] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
