### PR TITLE
Add force options to push client to overwrite the artifact

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -2267,12 +2267,12 @@ func testPushWithInsecureSkipTLSverify(t *testing.T) {
 	kpmcli, err := NewKpmClient()
 	assert.Equal(t, err, nil)
 
-	_ = kpmcli.pushToOci("test", ociOpts)
+	_ = kpmcli.pushToOci("test", ociOpts, &PushOptions{Force: false})
 
 	assert.Equal(t, buf.String(), "")
 
 	kpmcli.SetInsecureSkipTLSverify(true)
-	_ = kpmcli.pushToOci("test", ociOpts)
+	_ = kpmcli.pushToOci("test", ociOpts, &PushOptions{Force: false})
 
 	assert.Equal(t, buf.String(), "Called Success\n")
 }

--- a/pkg/client/push_test.go
+++ b/pkg/client/push_test.go
@@ -13,6 +13,22 @@ import (
 	"kcl-lang.io/kpm/pkg/reporter"
 )
 
+// pushWithForce - helper function for push operations with force parameter
+func pushWithForce(kpmcli *KpmClient, pushedModPath string, force bool) error {
+	return kpmcli.Push(
+		WithPushModPath(pushedModPath),
+		WithPushForce(force),
+		WithPushSource(
+			downloader.Source{
+				Oci: &downloader.Oci{
+					Reg:  "localhost:5002",
+					Repo: "test/push_0",
+				},
+			},
+		),
+	)
+}
+
 func TestPush(t *testing.T) {
 	testFunc := func(t *testing.T, kpmcli *KpmClient) {
 		if runtime.GOOS == "windows" {
@@ -42,25 +58,49 @@ func TestPush(t *testing.T) {
 		testDir := getTestDir("test_push")
 		pushedModPath := filepath.Join(testDir, "push_0")
 
-		err = kpmcli.Push(
-			WithPushModPath(pushedModPath),
-			WithPushSource(
-				downloader.Source{
-					Oci: &downloader.Oci{
-						Reg:  "localhost:5002",
-						Repo: "test/push_0",
-					},
-				},
-			),
-		)
+		// === Test 1: First push (should succeed) ===
+		t.Log("=== Test 1: First push should succeed ===")
+		err = pushWithForce(kpmcli, pushedModPath, false)
 
 		if err != (*reporter.KpmEvent)(nil) {
-			t.Errorf("Error pushing kcl package: %v", err)
+			t.Errorf("Error: First push should succeed: %v", err)
 		}
 
 		assert.Contains(t, buf.String(), "package 'push_0' will be pushed")
 		assert.Contains(t, buf.String(), "pushed [registry] localhost:5002/test/push_0")
 		assert.Contains(t, buf.String(), "digest: sha256:")
+
+		// Clean the buffer for the next test
+		buf.Reset()
+
+		// === Test 2: Second push with force (should overwrite) ===
+		t.Log("=== Test 2: Second push with force should overwrite ===")
+		err = pushWithForce(kpmcli, pushedModPath, true)
+
+		if err != (*reporter.KpmEvent)(nil) {
+			t.Errorf("Error: Second push with force should succeed: %v", err)
+		}
+
+		assert.Contains(t, buf.String(), "package 'push_0' will be pushed")
+		assert.Contains(t, buf.String(), "package version '0.0.1' already exists, force pushing")
+		assert.Contains(t, buf.String(), "pushed [registry] localhost:5002/test/push_0")
+
+		// Clean the buffer for the next test
+		buf.Reset()
+
+		// === Test 3: Third push without force (should fail) ===
+		t.Log("=== Test 3: Third push without force should fail ===")
+		err = pushWithForce(kpmcli, pushedModPath, false)
+
+		// Check that this operation failed
+		if err == (*reporter.KpmEvent)(nil) {
+			t.Errorf("Third push without force should fail, but it succeeded")
+		} else {
+			t.Logf("Expected error occurred: %v", err)
+
+			assert.Contains(t, buf.String(), "package 'push_0' will be pushed")
+			assert.Contains(t, err.Error(), "already exists")
+		}
 
 		testPushModPath := filepath.Join(testDir, "test_pushed_mod")
 
@@ -90,4 +130,36 @@ func TestPush(t *testing.T) {
 
 	}
 	RunTestWithGlobalLockAndKpmCli(t, []TestSuite{{Name: "TestPush", TestFunc: testFunc}})
+}
+
+// Simple unit test for the Force option
+func TestPushForceOption(t *testing.T) {
+	tests := []struct {
+		name     string
+		force    bool
+		expected bool
+	}{
+		{
+			name:     "Force enabled",
+			force:    true,
+			expected: true,
+		},
+		{
+			name:     "Force disabled",
+			force:    false,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := &PushOptions{}
+
+			option := WithPushForce(tt.force)
+			err := option(opts)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, opts.Force, "Force option should be set to %v", tt.expected)
+		})
+	}
 }

--- a/scripts/reg.sh
+++ b/scripts/reg.sh
@@ -30,5 +30,8 @@ docker run -p 5002:5002 \
 -e "REGISTRY_HTTP_ADDR=:5002" \
 -d registry
 
+# Wait for the container to start and registry to be ready
+for i in {1..60}; do nc -z 127.0.0.1 5002 && break || sleep 1; echo "Waiting for registry to start $i.."; done
+
 # clean the registry
 docker exec kcl-registry rm -rf /var/lib/registry/docker/registry/v2/repositories/


### PR DESCRIPTION
<!-- Thank you for contributing to KCL!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kcl-lang.io/docs/community/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) :

- [ ] N
- [X] Y 
  ench #645

#### 2. What is the scope of this PR (e.g. component or file name):

- pkg/client/client_test.go
- pkg/client/push.go
- pkg/client/push_test.go
- scripts/reg.sh

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [X] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other


This PR adds the possibility to override (replace) existing .tar artifacts in the remote registry (e.g., Artifactory) when pushing a package.
Motivation: In our CI process, we need to push updates to the same artifact name frequently, and deleting old packages before push is not convenient.
Adds --force  flag to the kpm push command
If the artifact exists and the flag is set, the push operation replaces the existing object
No behavior change unless the flag is used

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [X] N
- [ ] Y 

The default behavior does not change. Overriding only happens when the new flag is explicitly set.

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [X] Unit test
- [X] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other


Push a tar artifact with a given name to the registry.
Re-push the same artifact with the new flag enabled (--force).
Confirm that the existing artifact is replaced without a deletion step.
Push one more time without force and get an error with already esixts
