### PR TITLE
fix(#659): allow client to request credentials in each call via envvar

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -77,6 +77,11 @@ func (c *KpmClient) SetNoSumCheck(noSumCheck bool) {
 
 // GetCredsClient will return the credential client.
 func (c *KpmClient) GetCredsClient() (*downloader.CredClient, error) {
+	reloadCreds, _ := c.settings.ForceReloadCredsPerUse()
+	if reloadCreds {
+		return downloader.LoadCredentialFile(c.settings.CredentialsFile)
+	}
+
 	if c.credsClient == nil {
 		credCli, err := downloader.LoadCredentialFile(c.settings.CredentialsFile)
 		if err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing to KCL!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kcl-lang.io/docs/community/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

fix #659

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kcl-lang/kcl/src/parser 
-->

* `pkg/client/client.go`
* `pkg/settings/settings.go`

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [x] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

This PR adds support for a new environment variable `KPM_RELOAD_CREDS` (`on`/`off`). By default or when disabled everything works as before. Setting `KPM_RELOAD_CREDS=on` will tell the kpm client to reload downloader's credentials on every execution (credentials won't be cached anymore).

This in combination with a docker credentials helper that dynamically manages access to registries like AWS ECR, ensure that requests to the registry will never fail due to expired auth tokens.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
