### PR TITLE
fix: resolve empty tarball when target is current directory

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -134,7 +134,12 @@ func TarDir(srcDir string, tarPath string, include []string, exclude []string) e
 	defer tw.Close()
 
 	// In case the tarPath is within the current working directory, exclude it from the tar itself.
-	ignores := append(defaultIgnores, filepath.Join(srcDir, filepath.Dir(tarPath)))
+	targetDir := filepath.Join(srcDir, filepath.Dir(tarPath))
+	ignores := defaultIgnores
+	// Only ignore the target directory if it is NOT the root source directory.
+	if filepath.Clean(targetDir) != filepath.Clean(srcDir) {
+		ignores = append(ignores, targetDir)
+	}
 
 	err = filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

Fixes #678

#### 2. What is the scope of this PR (e.g. component or file name):

`pkg/utils/utils.go`

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

**Details:**
This PR fixes a bug where `kpm pkg --target .` generated an empty tarball. 

The issue was caused by logic that incorrectly added the target directory to the ignore list to prevent recursion. When the target is the current directory (`.`), this caused the file walker to ignore the entire project. This fix ensures the target directory is only ignored if it is different from the source root.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [x] Manual test (add detailed scripts or steps below)
- [ ] Other

**Details:**
Verified manually using the reproduction steps from the issue:
1. Created a test project with `kcl.mod` and `main.k`.
2. Ran `kpm pkg --target .`.
3. Verified via `tar -tf` that the output archive now contains the source files instead of being empty.
4. Ran `go test ./pkg/utils/...` to ensure no regressions.