### PR TITLE
feat(oci): conditionally use a fresh cache to avoid reusing stale token

### DIFF
--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -114,6 +114,18 @@ func (ociClient *OciClient) GetReference() string {
 	return ociClient.repo.Reference.String()
 }
 
+// newAuthCache returns a per-client cache when KPM_RELOAD_CREDS is enabled,
+// preventing stale Bearer tokens from being reused across OCI operations.
+// Otherwise it returns the global DefaultCache for backward compatibility.
+func newAuthCache(s *settings.Settings) remoteauth.Cache {
+	if s != nil {
+		if reloadCreds, ok := s.ForceReloadCredsPerUse(); ok && reloadCreds {
+			return remoteauth.NewCache()
+		}
+	}
+	return remoteauth.DefaultCache
+}
+
 // NewOciClientWithOpts will new an OciClient with options.
 func NewOciClientWithOpts(opts ...OciClientOption) (*OciClient, error) {
 	client := &OciClient{}
@@ -136,7 +148,7 @@ func NewOciClientWithOpts(opts ...OciClientOption) (*OciClient, error) {
 	ctx := context.Background()
 	client.repo.Client = &remoteauth.Client{
 		Client:     customClient,
-		Cache:      remoteauth.DefaultCache,
+		Cache:      newAuthCache(client.settings),
 		Credential: remoteauth.StaticCredential(client.repo.Reference.Host(), *client.cred),
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing to KCL!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kcl-lang.io/docs/community/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

fixes another usecase of #659 

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kcl-lang/kcl/src/parser 
-->

`pkg/oci/oci.go`

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

##### Problem

When `kpm` is used as a library inside a long-running process (e.g. `function-kcl` running as a gRPC server in Kubernetes), OCI Bearer tokens cached by `oras-go` persist indefinitely in `remoteauth.DefaultCache` — a process-global singleton with no TTL.

After the token expires (ECR tokens last ~12 hours), subsequent OCI operations fail with:

```sh
GET "https://<account>.dkr.ecr.<region>.amazonaws.com/v2/<repo>/tags/list":
response status code 403: denied: Your authorization token has expired. Reauthenticate and try again.
```

The key issue is that ECR returns **403 Forbidden** (not 401 Unauthorized) for expired tokens. `oras-go`'s `Client.Do()` only retries authentication on 401 responses — a 403 is returned as-is without re-authentication, so the stale cached token is never refreshed.

##### Solution
When `KPM_RELOAD_CREDS=on`, replace the global `remoteauth.DefaultCache` with a fresh per-client `remoteauth.NewCache()` for each `OciClient` instance. Since `kpm` already creates a new `OciClient` per OCI operation (download, tag listing, push, etc.), each operation starts with an empty cache, forcing `oras-go` to re-authenticate with fresh credentials.
When `KPM_RELOAD_CREDS` is not set, the behavior is identical to before — `DefaultCache` is used as the shared global cache.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
