### PR TITLE
feat: add KPM_NO_SUM env to work without checksum (#606)

### DIFF
--- a/pkg/checker/checker.go
+++ b/pkg/checker/checker.go
@@ -12,6 +12,7 @@ import (
 
 	"kcl-lang.io/kpm/pkg/constants"
 	"kcl-lang.io/kpm/pkg/downloader"
+	"kcl-lang.io/kpm/pkg/env"
 	"kcl-lang.io/kpm/pkg/oci"
 	"kcl-lang.io/kpm/pkg/opt"
 	pkg "kcl-lang.io/kpm/pkg/package"
@@ -147,6 +148,11 @@ func (sc *SumChecker) Check(kclPkg pkg.KclPkg) error {
 
 	for _, key := range kclPkg.Dependencies.Deps.Keys() {
 		dep, _ := kclPkg.Dependencies.Deps.Get(key)
+
+		if env.SkipChecksumCheck(dep.Name) {
+			continue
+		}
+
 		trustedSum, err := sc.getTrustedSum(dep)
 		if err != nil {
 			return fmt.Errorf("failed to get checksum from trusted source: %w", err)

--- a/pkg/client/update.go
+++ b/pkg/client/update.go
@@ -8,6 +8,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"kcl-lang.io/kpm/pkg/checker"
 	"kcl-lang.io/kpm/pkg/constants"
+	"kcl-lang.io/kpm/pkg/env"
 	"kcl-lang.io/kpm/pkg/features"
 	"kcl-lang.io/kpm/pkg/opt"
 	pkg "kcl-lang.io/kpm/pkg/package"
@@ -140,12 +141,14 @@ func (c *KpmClient) Update(options ...UpdateOption) (*pkg.KclPkg, error) {
 
 		selectedDep.LocalFullPath = dep.LocalFullPath
 		if selectedDep.Sum == "" {
-			sum, err := c.AcquireDepSum(*selectedDep)
-			if err != nil {
-				return err
-			}
-			if sum != "" {
-				selectedDep.Sum = sum
+			if !env.SkipChecksumCheck(selectedDep.Name) {
+				sum, err := c.AcquireDepSum(*selectedDep)
+				if err != nil {
+					return err
+				}
+				if sum != "" {
+					selectedDep.Sum = sum
+				}
 			}
 		}
 		kMod.Dependencies.Deps.Set(dep.Name, *selectedDep)

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -2,7 +2,9 @@ package env
 
 import (
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
 
 	"kcl-lang.io/kpm/pkg/reporter"
 	"kcl-lang.io/kpm/pkg/utils"
@@ -12,6 +14,7 @@ import (
 const PKG_PATH = "KCL_PKG_PATH"
 const MODULES_SUB_DIR = "modules"
 const KCL_DATA_DIR = "kcl"
+const KPM_NO_SUM = "KPM_NO_SUM"
 
 // GetEnvPkgPath will return the env $KCL_PKG_PATH.
 func GetEnvPkgPath() string {
@@ -51,4 +54,25 @@ func GetAbsPkgPath() (string, error) {
 	}
 
 	return kpmHome, nil
+}
+
+func SkipChecksumCheck(depName string) bool {
+	noSumEnv := os.Getenv(KPM_NO_SUM)
+	if noSumEnv == "" {
+		return false
+	}
+
+	patterns := strings.Split(noSumEnv, ",")
+	for _, pattern := range patterns {
+		pattern = strings.TrimSpace(pattern)
+		if pattern == "" {
+			continue
+		}
+
+		matched, err := path.Match(pattern, depName)
+		if err == nil && matched {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -22,3 +22,27 @@ func TestGetAbsPkgPath(t *testing.T) {
 	assert.Equal(t, got, filepath.Join(expect, "test_subdir"))
 	assert.Equal(t, err, nil)
 }
+
+func TestSkipChecksumCheck(t *testing.T) {
+	defer os.Unsetenv(KPM_NO_SUM)
+
+	// Test exact matches
+	os.Setenv(KPM_NO_SUM, "crossplane,k8s")
+	assert.Equal(t, SkipChecksumCheck("crossplane"), true)
+	assert.Equal(t, SkipChecksumCheck("k8s"), true)
+	assert.Equal(t, SkipChecksumCheck("json_merge_patch"), false)
+
+	// Test wildcard
+	os.Setenv(KPM_NO_SUM, "*")
+	assert.Equal(t, SkipChecksumCheck("anything"), true)
+	assert.Equal(t, SkipChecksumCheck("crossplane"), true)
+
+	// Test prefix wildcard
+	os.Setenv(KPM_NO_SUM, "k8s-*")
+	assert.Equal(t, SkipChecksumCheck("k8s-utils"), true)
+	assert.Equal(t, SkipChecksumCheck("crossplane"), false)
+
+	// Test empty environment variable
+	os.Setenv(KPM_NO_SUM, "")
+	assert.Equal(t, SkipChecksumCheck("crossplane"), false)
+}


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

fix #606, re #605

#### 2. What is the scope of this PR (e.g. component or file name):

`pkg/env/env.go`, `pkg/env/env_test.go`, `pkg/client/update.go`, `pkg/checker/checker.go`

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

Adds a `KPM_NO_SUM` environment variable so users can skip downloading and verifying checksums for specific dependencies. This is super helpful for offline setups or when pulling from internal/private registries where public checksum checks either fail or slow things down.

**What changed:**
* **`pkg/env/env.go`**: Added a `SkipChecksumCheck` helper. It parses a comma-separated `KPM_NO_SUM` list and uses `path.Match` to support exact matches and `*` wildcards across platforms.
* **`pkg/client/update.go`**: Skips the `AcquireDepSum` network call entirely if the dependency is on the skip list.
* **`pkg/checker/checker.go`**: `SumChecker` now ignores validation for skipped dependencies so it doesn't throw mismatch errors.

**Note on kcl.mod.lock:** Because we bypass `AcquireDepSum`, skipped dependencies will be written to the lockfile with an empty `sum` field. This is expected and intended behavior for offline/internal environments.

**Usage:**
* Skip specific ones: `export KPM_NO_SUM="crossplane,k8s"`
* Skip by prefix: `export KPM_NO_SUM="k8s-*"`
* Skip everything: `export KPM_NO_SUM="*"`

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

Added `TestSkipChecksumCheck` in `pkg/env/env_test.go` to verify exact matches, wildcard/prefix matches, and empty environment variable handling.