### PR TITLE
fix(auth): restore deterministic login and logout validation

### DIFF
--- a/pkg/client/logout.go
+++ b/pkg/client/logout.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	remoteauth "oras.land/oras-go/v2/registry/remote/auth"
 	"kcl-lang.io/kpm/pkg/reporter"
 	"oras.land/oras-go/v2/registry/remote/credentials"
 )
@@ -16,6 +17,15 @@ func (c *KpmClient) LogoutOci(hostname string) error {
 	}
 
 	store := credStore.GetAuthStore()
+	serverAddress := credentials.ServerAddressFromRegistry(hostname)
+	cred, err := store.Get(context.Background(), serverAddress)
+	if err != nil {
+		return err
+	}
+	if cred == remoteauth.EmptyCredential {
+		return reporter.NewErrorEvent(reporter.FailedLogout, fmt.Errorf("not logged in"), fmt.Sprintf("failed to logout '%s'", hostname))
+	}
+
 	err = credentials.Logout(context.Background(), store, hostname)
 
 	if err != nil {

--- a/pkg/client/logout_test.go
+++ b/pkg/client/logout_test.go
@@ -1,0 +1,19 @@
+package client
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogoutWithoutStoredCredential(t *testing.T) {
+	kpmcli, err := NewKpmClient()
+	assert.NoError(t, err)
+
+	kpmcli.settings.CredentialsFile = filepath.Join(t.TempDir(), "config.json")
+	kpmcli.credsStore = nil
+
+	err = kpmcli.LogoutOci("invalid_registry")
+	assert.EqualError(t, err, "failed to logout 'invalid_registry'\nnot logged in\n")
+}

--- a/pkg/cmd/cmd_login.go
+++ b/pkg/cmd/cmd_login.go
@@ -40,6 +40,12 @@ func NewLoginCmd(kpmcli *client.KpmClient) *cli.Command {
 					fmt.Errorf("registry must be specified"),
 				)
 			}
+			if c.String("password") != "" && c.String("username") == "" {
+				return reporter.NewErrorEvent(
+					reporter.InvalidCmd,
+					fmt.Errorf("username must be specified when password is provided"),
+				)
+			}
 			registry := c.Args().First()
 
 			username, password, err := utils.GetUsernamePassword(c.String("username"), c.String("password"), c.Bool("password-stdin"))

--- a/pkg/cmd/cmd_login_test.go
+++ b/pkg/cmd/cmd_login_test.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v2"
+	"kcl-lang.io/kpm/pkg/client"
+)
+
+func TestLoginRejectsPasswordWithoutUsername(t *testing.T) {
+	kpmcli, err := client.NewKpmClient()
+	assert.NoError(t, err)
+
+	app := &cli.App{
+		Commands: []*cli.Command{
+			NewLoginCmd(kpmcli),
+		},
+	}
+
+	err = app.Run([]string{"kpm", "login", "-p", "aaaa", "ghcr.io"})
+	assert.EqualError(t, err, "username must be specified when password is provided\n")
+}

--- a/test/e2e/test_suites/kpm/exec_outside_pkg/login_reg_without_username/test_suite.stderr
+++ b/test/e2e/test_suites/kpm/exec_outside_pkg/login_reg_without_username/test_suite.stderr
@@ -1,2 +1,1 @@
-failed to login 'ghcr.io', please check registry, username and password is valid
-Get "https://ghcr.io/v2/": unsupported
+username must be specified when password is provided


### PR DESCRIPTION
## 1. Related Issue
- fix #708

## 2. What changes were made?
- reject `kpm login -p ...` without `--username` before calling ORAS or the remote registry
- make `kpm logout` report `not logged in` again when no stored credential exists
- add command and client regression tests for the new validation
- update the affected e2e expectation to the new stable login error

## 3. Description
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

This restores deterministic behavior to the deprecated registry auth commands after the ORAS upgrade. Invalid inputs now fail locally with stable messages instead of depending on whatever a registry or credential store happens to return.

## 4. Does this introduce breaking changes?
- No.

## 5. How was this tested?
- `go test ./pkg/cmd -run TestLoginRejectsPasswordWithoutUsername -count=1`
- `go test ./pkg/client -run TestLogoutWithoutStoredCredential -count=1`
- `./bin/kpm login -p aaaa ghcr.io`
- `./bin/kpm logout invalid_registry`
