### PR TITLE
fix(archive): support .tgz package archives across pull and run paths

### DIFF
--- a/pkg/api/kpm_run.go
+++ b/pkg/api/kpm_run.go
@@ -7,7 +7,6 @@ import (
 
 	"kcl-lang.io/kcl-go/pkg/kcl"
 	"kcl-lang.io/kpm/pkg/client"
-	"kcl-lang.io/kpm/pkg/constants"
 	"kcl-lang.io/kpm/pkg/env"
 	"kcl-lang.io/kpm/pkg/errors"
 	"kcl-lang.io/kpm/pkg/oci"
@@ -116,7 +115,7 @@ func RunCurrentPkg(opts *opt.CompileOptions) (*kcl.KCLResultList, error) {
 
 // RunTarPkg will compile the kcl package from a kcl package tar.
 func RunTarPkg(tarPath string, opts *opt.CompileOptions) (*kcl.KCLResultList, error) {
-	absTarPath, err := utils.AbsTarPath(tarPath)
+	absTarPath, err := utils.AbsPkgArchivePath(tarPath)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +123,7 @@ func RunTarPkg(tarPath string, opts *opt.CompileOptions) (*kcl.KCLResultList, er
 	// e.g.
 	// 'xxx/xxx/xxx/test.tar' will be extracted to the directory 'xxx/xxx/xxx/test'.
 	destDir := strings.TrimSuffix(absTarPath, filepath.Ext(absTarPath))
-	err = utils.UnTarDir(absTarPath, destDir)
+	err = utils.ExtractPkgArchive(absTarPath, destDir)
 	if err != nil {
 		return nil, err
 	}
@@ -173,18 +172,13 @@ func RunOciPkg(ociRef, version string, opts *opt.CompileOptions) (*kcl.KCLResult
 		return nil, err
 	}
 
-	// 3.Get the (*.tar) file path.
-	matches, err := filepath.Glob(filepath.Join(localPath, constants.KCL_PKG_TAR))
-	if err != nil || len(matches) != 1 {
-		if err != nil {
-			return nil, reporter.NewErrorEvent(reporter.FailedGetPkg, err, "failed to pull kcl package")
-		} else {
-			return nil, errors.FailedPull
-		}
+	archivePath, err := utils.FindPkgArchive(localPath)
+	if err != nil {
+		return nil, reporter.NewErrorEvent(reporter.FailedGetPkg, err, "failed to pull kcl package")
 	}
 
 	// 4. Untar the tar file.
-	absTarPath, err := utils.AbsTarPath(matches[0])
+	absTarPath, err := utils.AbsPkgArchivePath(archivePath)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +186,7 @@ func RunOciPkg(ociRef, version string, opts *opt.CompileOptions) (*kcl.KCLResult
 	// e.g.
 	// 'xxx/xxx/xxx/test.tar' will be extracted to the directory 'xxx/xxx/xxx/test'.
 	destDir := strings.TrimSuffix(absTarPath, filepath.Ext(absTarPath))
-	err = utils.UnTarDir(absTarPath, destDir)
+	err = utils.ExtractPkgArchive(absTarPath, destDir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/kpm_run_test.go
+++ b/pkg/api/kpm_run_test.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"compress/gzip"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -154,6 +156,43 @@ func TestRunTarPkg(t *testing.T) {
 	if utils.DirExists(untarPath) {
 		os.RemoveAll(untarPath)
 	}
+}
+
+func gzipTestArchive(t *testing.T, srcPath, dstPath string) {
+	t.Helper()
+
+	src, err := os.Open(srcPath)
+	assert.NoError(t, err)
+	defer src.Close()
+
+	dst, err := os.Create(dstPath)
+	assert.NoError(t, err)
+	defer dst.Close()
+
+	gzipWriter := gzip.NewWriter(dst)
+	_, err = io.Copy(gzipWriter, src)
+	assert.NoError(t, err)
+	assert.NoError(t, gzipWriter.Close())
+}
+
+func TestRunTgzPkg(t *testing.T) {
+	pkgPath := getTestDir("test_run_tar_in_path")
+	tmpDir := t.TempDir()
+	tgzPath := filepath.Join(tmpDir, "test.tgz")
+	gzipTestArchive(t, filepath.Join(pkgPath, "test.tar"), tgzPath)
+	untarPath := strings.TrimSuffix(tgzPath, filepath.Ext(tgzPath))
+	expectPath := filepath.Join(pkgPath, "expected")
+	expectPathJson := filepath.Join(pkgPath, "expected.json")
+
+	expectedResult, _ := os.ReadFile(expectPath)
+	expectedResultJson, _ := os.ReadFile(expectPathJson)
+	opts := opt.DefaultCompileOptions()
+	opts.SetVendor(true)
+	gotResult, err := RunTarPkg(tgzPath, opts)
+	assert.NoError(t, err)
+	assert.Equal(t, utils.RmNewline(string(expectedResult)), utils.RmNewline(gotResult.GetRawYamlResult()))
+	assert.Equal(t, utils.RmNewline(string(expectedResultJson)), utils.RmNewline(gotResult.GetRawJsonResult()))
+	assert.True(t, utils.DirExists(untarPath))
 }
 
 func testRunWithNoSumCheck(t *testing.T) {

--- a/pkg/client/deperated.go
+++ b/pkg/client/deperated.go
@@ -1025,29 +1025,23 @@ func (c *KpmClient) PullFromOci(localPath, source, tag string) error {
 		return err
 	}
 
-	// Get the (*.tar) file path.
-	tarPath := filepath.Join(storepath, constants.KCL_PKG_TAR)
-	matches, err := filepath.Glob(tarPath)
-	if err != nil || len(matches) != 1 {
-		if err == nil {
-			err = errors.InvalidPkg
-		}
-
+	tarPath, err := utils.FindPkgArchive(storepath)
+	if err != nil {
 		return reporter.NewErrorEvent(
 			reporter.InvalidKclPkg,
-			err,
-			fmt.Sprintf("failed to find the kcl package tar from '%s'.", tarPath),
+			errors.InvalidPkg,
+			fmt.Sprintf("failed to find the kcl package tar from '%s'.", filepath.Join(storepath, constants.KCL_PKG_TAR)),
 		)
 	}
 
 	// Untar the tar file.
 	storagePath := ociOpts.SanitizePathWithSuffix(localPath)
-	err = utils.UnTarDir(matches[0], storagePath)
+	err = utils.ExtractPkgArchive(tarPath, storagePath)
 	if err != nil {
 		return reporter.NewErrorEvent(
 			reporter.FailedUntarKclPkg,
 			err,
-			fmt.Sprintf("failed to untar the kcl package tar from '%s' into '%s'.", matches[0], storagePath),
+			fmt.Sprintf("failed to untar the kcl package tar from '%s' into '%s'.", tarPath, storagePath),
 		)
 	}
 

--- a/pkg/downloader/source.go
+++ b/pkg/downloader/source.go
@@ -137,7 +137,7 @@ func (source *Source) IsRemote() bool {
 }
 
 func (source *Source) IsPackaged() bool {
-	return source.IsLocalTarPath() || source.Git != nil || source.Oci != nil || !source.ModSpec.IsNil()
+	return source.IsLocalTarPath() || source.IsLocalTgzPath() || source.Git != nil || source.Oci != nil || !source.ModSpec.IsNil()
 }
 
 // If the source is a local path, check if it is a real local package(a directory with kcl.mod file).
@@ -170,7 +170,7 @@ func (local *Local) IsLocalTarPath() bool {
 }
 
 func (local *Local) IsLocalTgzPath() bool {
-	return local != nil && filepath.Ext(local.Path) == constants.TarPathSuffix
+	return local != nil && filepath.Ext(local.Path) == constants.TgzPathSuffix
 }
 
 func (local *Local) IsLocalKPath() bool {

--- a/pkg/downloader/source_test.go
+++ b/pkg/downloader/source_test.go
@@ -27,3 +27,15 @@ func TestParseModSpecFromStr(t *testing.T) {
 		})
 	}
 }
+
+func TestLocalArchiveSourceDetection(t *testing.T) {
+	tarSource := &Source{Local: &Local{Path: "/tmp/test.tar"}}
+	assert.Equal(t, tarSource.IsLocalTarPath(), true)
+	assert.Equal(t, tarSource.IsLocalTgzPath(), false)
+	assert.Equal(t, tarSource.IsPackaged(), true)
+
+	tgzSource := &Source{Local: &Local{Path: "/tmp/test.tgz"}}
+	assert.Equal(t, tgzSource.IsLocalTarPath(), false)
+	assert.Equal(t, tgzSource.IsLocalTgzPath(), true)
+	assert.Equal(t, tgzSource.IsPackaged(), true)
+}

--- a/pkg/package/package.go
+++ b/pkg/package/package.go
@@ -305,12 +305,7 @@ func FindFirstKclPkgFrom(pkgpath string) (*KclPkg, error) {
 
 	tarPath := matches[0]
 	unTarPath := filepath.Dir(tarPath)
-	var err error
-	if utils.IsTar(tarPath) {
-		err = utils.UnTarDir(tarPath, unTarPath)
-	} else {
-		err = utils.ExtractTarball(tarPath, unTarPath)
-	}
+	err := utils.ExtractPkgArchive(tarPath, unTarPath)
 	if err != nil {
 		return nil, reporter.NewErrorEvent(
 			reporter.FailedUntarKclPkg,
@@ -346,8 +341,12 @@ func FindFirstKclPkgFrom(pkgpath string) (*KclPkg, error) {
 // LoadKclPkgFromTar loads a package *.tar file from the 'pkgTarPath'
 // The default oci registry in '$KCL_PKG_PATH/.kpm/config/kpm.json' will be used.
 func LoadKclPkgFromTar(pkgTarPath string) (*KclPkg, error) {
-	destDir := strings.TrimSuffix(pkgTarPath, filepath.Ext(pkgTarPath))
-	err := utils.UnTarDir(pkgTarPath, destDir)
+	absTarPath, err := utils.AbsPkgArchivePath(pkgTarPath)
+	if err != nil {
+		return nil, err
+	}
+	destDir := strings.TrimSuffix(absTarPath, filepath.Ext(absTarPath))
+	err = utils.ExtractPkgArchive(absTarPath, destDir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/package/package_test.go
+++ b/pkg/package/package_test.go
@@ -1,8 +1,11 @@
 package pkg
 
 import (
+	"compress/gzip"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -137,6 +140,37 @@ func TestLoadKclPkgFromTar(t *testing.T) {
 	assert.Equal(t, utils.DirExists(filepath.Join(testDir, "kcl1-v0.0.3")), true)
 	err = os.RemoveAll(filepath.Join(testDir, "kcl1-v0.0.3"))
 	assert.Equal(t, err, nil)
+}
+
+func gzipArchiveFile(t *testing.T, srcPath, dstPath string) {
+	t.Helper()
+
+	src, err := os.Open(srcPath)
+	assert.NoError(t, err)
+	defer src.Close()
+
+	dst, err := os.Create(dstPath)
+	assert.NoError(t, err)
+	defer dst.Close()
+
+	gzipWriter := gzip.NewWriter(dst)
+	_, err = io.Copy(gzipWriter, src)
+	assert.NoError(t, err)
+	assert.NoError(t, gzipWriter.Close())
+}
+
+func TestLoadKclPkgFromTgz(t *testing.T) {
+	testDir := getTestDir("load_kcl_tar")
+	tmpDir := t.TempDir()
+	tgzPath := filepath.Join(tmpDir, "kcl1-v0.0.3.tgz")
+	gzipArchiveFile(t, filepath.Join(testDir, "kcl1-v0.0.3.tar"), tgzPath)
+
+	kclPkg, err := LoadKclPkgFromTar(tgzPath)
+	assert.NoError(t, err)
+	assert.Equal(t, kclPkg.ModFile.Pkg.Name, "kcl1")
+	assert.Equal(t, kclPkg.ModFile.Pkg.Version, "0.0.3")
+
+	assert.NoError(t, os.RemoveAll(strings.TrimSuffix(tgzPath, filepath.Ext(tgzPath))))
 }
 
 // Test load package whose dependencies in kcl.mod and kcl.mod.lock is different

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -625,6 +625,16 @@ func IsTar(str string) bool {
 	return strings.HasSuffix(str, constants.TarPathSuffix)
 }
 
+// IsTgz will check whether the string 'str' is a tgz path.
+func IsTgz(str string) bool {
+	return strings.HasSuffix(str, constants.TgzPathSuffix)
+}
+
+// IsPkgArchive will check whether the string 'str' is a supported package archive path.
+func IsPkgArchive(str string) bool {
+	return IsTar(str) || IsTgz(str)
+}
+
 // IsKfile will check whether the string 'str' is a k file path.
 func IsKfile(str string) bool {
 	return strings.HasSuffix(str, constants.KFilePathSuffix)
@@ -661,6 +671,34 @@ func AbsTarPath(tarPath string) (string, error) {
 	}
 
 	return absTarPath, nil
+}
+
+// AbsPkgArchivePath checks whether path 'archivePath' exists and whether path 'archivePath'
+// ends with '.tar' or '.tgz'. And after checking, it returns the absolute path.
+func AbsPkgArchivePath(archivePath string) (string, error) {
+	absArchivePath, err := filepath.Abs(archivePath)
+	if err != nil {
+		return "", err
+	}
+
+	if !IsPkgArchive(absArchivePath) {
+		return "", errors.InvalidKclPacakgeTar
+	} else if !DirExists(absArchivePath) {
+		return "", errors.KclPacakgeTarNotFound
+	}
+
+	return absArchivePath, nil
+}
+
+// ExtractPkgArchive extracts a package archive in '.tar' or '.tgz' format to 'destDir'.
+func ExtractPkgArchive(archivePath string, destDir string) error {
+	if IsTar(archivePath) {
+		return UnTarDir(archivePath, destDir)
+	}
+	if IsTgz(archivePath) {
+		return ExtractTarball(archivePath, destDir)
+	}
+	return errors.InvalidKclPacakgeTar
 }
 
 // FindPackage finds the package with the package name 'targetPackage' under the 'root' directory kcl.mod file.

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"archive/tar"
+	"compress/gzip"
 	"fmt"
 	"io"
 	"os"
@@ -237,6 +238,11 @@ func TestIsTar(t *testing.T) {
 	assert.Equal(t, IsTar("xxx.tar"), true)
 }
 
+func TestIsTgz(t *testing.T) {
+	assert.Equal(t, IsTgz("invalid tgz"), false)
+	assert.Equal(t, IsTgz("xxx.tgz"), true)
+}
+
 func TestIsKfile(t *testing.T) {
 	assert.Equal(t, IsKfile("invalid kfile"), false)
 	assert.Equal(t, IsKfile("xxx.k"), true)
@@ -257,6 +263,58 @@ func TestAbsTarPath(t *testing.T) {
 	abs, err = AbsTarPath(filepath.Join(pkgPath, "invalid_tar"))
 	assert.NotEqual(t, err, nil)
 	assert.Equal(t, abs, "")
+}
+
+func TestAbsPkgArchivePath(t *testing.T) {
+	testDir := t.TempDir()
+	tarPath := filepath.Join(testDir, "test.tar")
+	tgzPath := filepath.Join(testDir, "test.tgz")
+	assert.NoError(t, os.WriteFile(tarPath, []byte("tar"), 0644))
+	assert.NoError(t, os.WriteFile(tgzPath, []byte("tgz"), 0644))
+
+	abs, err := AbsPkgArchivePath(tarPath)
+	assert.NoError(t, err)
+	assert.Equal(t, abs, tarPath)
+
+	abs, err = AbsPkgArchivePath(tgzPath)
+	assert.NoError(t, err)
+	assert.Equal(t, abs, tgzPath)
+
+	abs, err = AbsPkgArchivePath(filepath.Join(testDir, "invalid.zip"))
+	assert.Error(t, err)
+	assert.Equal(t, abs, "")
+}
+
+func gzipTarFile(t *testing.T, srcPath, dstPath string) {
+	t.Helper()
+
+	src, err := os.Open(srcPath)
+	assert.NoError(t, err)
+	defer src.Close()
+
+	dst, err := os.Create(dstPath)
+	assert.NoError(t, err)
+	defer dst.Close()
+
+	gzipWriter := gzip.NewWriter(dst)
+	_, err = io.Copy(gzipWriter, src)
+	assert.NoError(t, err)
+	assert.NoError(t, gzipWriter.Close())
+}
+
+func TestExtractPkgArchive(t *testing.T) {
+	testDir := getTestDir("test_un_tar")
+	tarPath := filepath.Join(testDir, "test.tar")
+
+	tarDest := filepath.Join(t.TempDir(), "tar")
+	assert.NoError(t, ExtractPkgArchive(tarPath, tarDest))
+	assert.True(t, DirExists(tarDest))
+
+	tgzPath := filepath.Join(t.TempDir(), "test.tgz")
+	gzipTarFile(t, tarPath, tgzPath)
+	tgzDest := filepath.Join(t.TempDir(), "tgz")
+	assert.NoError(t, ExtractPkgArchive(tgzPath, tgzDest))
+	assert.True(t, DirExists(tgzDest))
 }
 
 func TestIsSymlinkExist(t *testing.T) {


### PR DESCRIPTION
## 1. Related Issue
- fix #704

## 2. What changes were made?
- add shared utility helpers for `.tar` and `.tgz` package archives
- recognize local `.tgz` sources as packaged archive inputs
- teach the deprecated `kpm pull` path, `RunTarPkg`, `RunOciPkg`, and package loading helpers to extract `.tgz` archives correctly
- add regression tests for source detection, archive helpers, package loading, and `RunTarPkg`

## 3. Description
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

This closes the gap opened by OCI tar+gzip layers on `main`. The CLI and helper APIs now treat `.tgz` package archives consistently across pull, run, and local archive loading paths.

## 4. Does this introduce breaking changes?
- No.

## 5. How was this tested?
- `go test ./pkg/downloader ./pkg/utils ./pkg/package ./pkg/api -run 'TestLocalArchiveSourceDetection|TestIsTgz|TestAbsPkgArchivePath|TestExtractPkgArchive|TestLoadKclPkgFromTgz|TestRunTgzPkg|TestRunTarPkg' -count=1`
- `./scripts/reg.sh && ./scripts/e2e_prepare.sh`
- `KPM_REG=localhost:5002 KPM_REPO=test OCI_REG_PLAIN_HTTP=ON ./bin/kpm pull oci://localhost:5002/test/k8s`
- `KPM_REG=localhost:5002 KPM_REPO=test OCI_REG_PLAIN_HTTP=ON ./bin/kpm pull k8s`
- `KPM_REG=localhost:5002 KPM_REPO=test OCI_REG_PLAIN_HTTP=ON ./bin/kpm pull oci://localhost:5002/test/helloworld`
