### PR TITLE
feat(oci): support for host-less oci dependencies as described in #739

### DIFF
--- a/pkg/downloader/source.go
+++ b/pkg/downloader/source.go
@@ -52,6 +52,12 @@ type Oci struct {
 	Reg  string `toml:"reg,omitempty"`
 	Repo string `toml:"repo,omitempty"`
 	Tag  string `toml:"oci_tag,omitempty"`
+	// RegFromEnv is true when the registry host was absent in the source declaration
+	// (e.g. `repo = "org/path/pkg"` in kcl.mod).  The host is resolved at runtime
+	// from KPM_REG / DefaultOciRegistry and must NOT be persisted back to kcl.mod or
+	// kcl.mod.lock — this flag tells the marshal path to preserve the host-less form
+	// even after Reg has been temporarily filled for the network call.
+	RegFromEnv bool `toml:"-"`
 }
 
 // If the OCI source has no reference, return true.
@@ -502,6 +508,11 @@ func (oci *Oci) FromString(ociStr string) error {
 	oci.Reg = u.Host
 	oci.Repo = strings.TrimPrefix(u.Path, "/")
 	oci.Tag = u.Query().Get(constants.Tag)
+	// Mark host-less sources so the marshal path keeps them host-less after
+	// Reg has been temporarily filled from KPM_REG / DefaultOciRegistry.
+	if oci.Reg == "" {
+		oci.RegFromEnv = true
+	}
 
 	return nil
 }

--- a/pkg/downloader/toml.go
+++ b/pkg/downloader/toml.go
@@ -52,10 +52,8 @@ func (source *Source) MarshalTOML() string {
 
 		if source.Oci != nil {
 			tomlStr = source.Oci.MarshalTOML()
-			if len(tomlStr) != 0 {
-				if len(source.Oci.Reg) != 0 && len(source.Oci.Repo) != 0 {
-					tomlStr = fmt.Sprintf(SOURCE_PATTERN, tomlStr+pkgSpec)
-				}
+			if len(tomlStr) != 0 && len(source.Oci.Repo) != 0 {
+				tomlStr = fmt.Sprintf(SOURCE_PATTERN, tomlStr+pkgSpec)
 			}
 		}
 
@@ -113,10 +111,20 @@ func (git *Git) MarshalTOML() string {
 }
 
 const OCI_URL_PATTERN = "oci = \"%s\""
+const OCI_REPO_PATTERN = "repo = \"%s\""
 
 func (oci *Oci) MarshalTOML() string {
 	var sb strings.Builder
-	if len(oci.Reg) != 0 && len(oci.Repo) != 0 {
+	// Host-less dependency: registry resolved at runtime from KPM_REG / DefaultOciRegistry.
+	// This branch is checked first so that a temporarily-filled Reg (from the network call)
+	// does not get persisted when RegFromEnv is set.
+	if (oci.RegFromEnv || len(oci.Reg) == 0) && len(oci.Repo) != 0 {
+		sb.WriteString(fmt.Sprintf(OCI_REPO_PATTERN, oci.Repo))
+		if len(oci.Tag) != 0 {
+			sb.WriteString(SEPARATOR)
+			sb.WriteString(fmt.Sprintf(TAG_PATTERN, oci.Tag))
+		}
+	} else if len(oci.Reg) != 0 && len(oci.Repo) != 0 {
 		sb.WriteString(fmt.Sprintf(OCI_URL_PATTERN, oci.IntoOciUrl()))
 		if len(oci.Tag) != 0 {
 			sb.WriteString(SEPARATOR)
@@ -157,6 +165,14 @@ func (source *Source) UnmarshalModTOML(data interface{}) error {
 			}
 			source.Git = &git
 		} else if _, ok := meta["oci"]; ok {
+			oci := Oci{}
+			err := oci.UnmarshalModTOML(data)
+			if err != nil {
+				return err
+			}
+			source.Oci = &oci
+		} else if _, ok := meta[OCI_REPO_FLAG]; ok {
+			// Host-less OCI dependency: `repo = "org/path/pkg"` with no registry host.
 			oci := Oci{}
 			err := oci.UnmarshalModTOML(data)
 			if err != nil {
@@ -207,6 +223,8 @@ const TAG_FLAG = "tag"
 const GIT_COMMIT_FLAG = "commit"
 const GIT_BRANCH_FLAG = "branch"
 const GIT_PACKAGE_FLAG = "package"
+const OCI_REPO_FLAG = "repo"
+const OCI_REG_FLAG = "reg"
 
 func (git *Git) UnmarshalModTOML(data interface{}) error {
 	meta, ok := data.(map[string]interface{})
@@ -239,6 +257,7 @@ func (git *Git) UnmarshalModTOML(data interface{}) error {
 
 func (oci *Oci) UnmarshalModTOML(data interface{}) error {
 	if meta, ok := data.(map[string]interface{}); ok {
+		// Full-URL form: oci = "oci://host/repo"
 		if v, ok := meta[constants.OciScheme].(string); ok {
 			err := oci.FromString(v)
 			if err != nil {
@@ -246,8 +265,22 @@ func (oci *Oci) UnmarshalModTOML(data interface{}) error {
 			}
 		}
 
+		// Host-less form: repo = "org/path/pkg" (registry resolved from KPM_REG at runtime)
+		if v, ok := meta[OCI_REPO_FLAG].(string); ok {
+			oci.Repo = v
+		}
+		if v, ok := meta[OCI_REG_FLAG].(string); ok {
+			oci.Reg = v
+		}
+
 		if v, ok := meta[TAG_FLAG].(string); ok {
 			oci.Tag = v
+		}
+
+		// Mark as host-less if no registry was declared; the host will be
+		// resolved from KPM_REG / DefaultOciRegistry at runtime.
+		if oci.Reg == "" && oci.Repo != "" {
+			oci.RegFromEnv = true
 		}
 	}
 

--- a/pkg/downloader/toml_test.go
+++ b/pkg/downloader/toml_test.go
@@ -1,0 +1,147 @@
+// Copyright 2024 The KCL Authors. All rights reserved.
+package downloader
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// TestOciHostlessMarshal verifies that an Oci with no registry host (host-less
+// dependency resolved from KPM_REG / DefaultOciRegistry at runtime) is serialised
+// using the `repo = "..."` key instead of a full `oci = "oci://host/..."` URL,
+// both when RegFromEnv was set at parse time and when Reg has been temporarily
+// filled for the network call but RegFromEnv is still true.
+func TestOciHostlessMarshal(t *testing.T) {
+	// Basic host-less: Reg is empty, RegFromEnv set
+	oci := &Oci{
+		Reg:        "",
+		Repo:       "myorg/kcl-templates/utils",
+		Tag:        "0.4.0",
+		RegFromEnv: true,
+	}
+	got := oci.MarshalTOML()
+	assert.Equal(t, got, `repo = "myorg/kcl-templates/utils", tag = "0.4.0"`)
+
+	// Reg temporarily filled (by resolution), but RegFromEnv is set → still host-less
+	ociResolved := &Oci{
+		Reg:        "672819064798.dkr.ecr.eu-west-1.amazonaws.com",
+		Repo:       "myorg/kcl-templates/utils",
+		Tag:        "0.4.0",
+		RegFromEnv: true,
+	}
+	got = ociResolved.MarshalTOML()
+	assert.Equal(t, got, `repo = "myorg/kcl-templates/utils", tag = "0.4.0"`)
+}
+
+// TestOciFullUrlMarshal verifies that existing full-URL behaviour is unchanged.
+func TestOciFullUrlMarshal(t *testing.T) {
+	oci := &Oci{
+		Reg:  "ghcr.io",
+		Repo: "kcl-lang/helloworld",
+		Tag:  "0.1.0",
+	}
+	got := oci.MarshalTOML()
+	assert.Equal(t, got, `oci = "oci://ghcr.io/kcl-lang/helloworld", tag = "0.1.0"`)
+}
+
+// TestOciShortNameMarshal verifies that the short-name form (no host, no repo) is unchanged.
+func TestOciShortNameMarshal(t *testing.T) {
+	oci := &Oci{Tag: "0.1.0"}
+	got := oci.MarshalTOML()
+	assert.Equal(t, got, `"0.1.0"`)
+}
+
+// TestOciHostlessUnmarshal verifies that `repo = "..."` in a kcl.mod map is
+// parsed into Oci with Reg="", RegFromEnv=true and Repo/Tag set correctly.
+func TestOciHostlessUnmarshal(t *testing.T) {
+	data := map[string]interface{}{
+		"repo": "myorg/kcl-templates/utils",
+		"tag":  "0.4.0",
+	}
+	oci := &Oci{}
+	err := oci.UnmarshalModTOML(data)
+	assert.NilError(t, err)
+	assert.Equal(t, oci.Repo, "myorg/kcl-templates/utils")
+	assert.Equal(t, oci.Tag, "0.4.0")
+	assert.Equal(t, oci.Reg, "")
+	assert.Equal(t, oci.RegFromEnv, true)
+}
+
+// TestSourceHostlessUnmarshal verifies that Source.UnmarshalModTOML dispatches
+// to OCI when the `repo` key is present and no `oci` key exists.
+func TestSourceHostlessUnmarshal(t *testing.T) {
+	data := map[string]interface{}{
+		"repo":    "myorg/kcl-templates/utils",
+		"tag":     "0.4.0",
+		"version": "0.4.0",
+	}
+	src := &Source{}
+	err := src.UnmarshalModTOML(data)
+	assert.NilError(t, err)
+	assert.Assert(t, src.Oci != nil, "expected Oci to be non-nil")
+	assert.Equal(t, src.Oci.Repo, "myorg/kcl-templates/utils")
+	assert.Equal(t, src.Oci.Tag, "0.4.0")
+	assert.Equal(t, src.Oci.Reg, "")
+	assert.Equal(t, src.Oci.RegFromEnv, true)
+	assert.Assert(t, src.ModSpec != nil, "expected ModSpec to be non-nil")
+	assert.Equal(t, src.ModSpec.Version, "0.4.0")
+}
+
+// TestOciHostlessMarshalRoundTrip verifies the full marshal→unmarshal round-trip
+// for a host-less OCI dependency, including the Source wrapper with version.
+func TestOciHostlessMarshalRoundTrip(t *testing.T) {
+	src := &Source{
+		Oci: &Oci{
+			Repo:       "myorg/kcl-templates/utils",
+			Tag:        "0.4.0",
+			RegFromEnv: true,
+		},
+		ModSpec: &ModSpec{Version: "0.4.0"},
+	}
+
+	marshaled := src.MarshalTOML()
+	// Expected: { repo = "myorg/kcl-templates/utils", tag = "0.4.0", version = "0.4.0" }
+	assert.Equal(t, marshaled, `{ repo = "myorg/kcl-templates/utils", tag = "0.4.0", version = "0.4.0" }`)
+
+	// Round-trip: unmarshal back
+	data := map[string]interface{}{
+		"repo":    "myorg/kcl-templates/utils",
+		"tag":     "0.4.0",
+		"version": "0.4.0",
+	}
+	src2 := &Source{}
+	err := src2.UnmarshalModTOML(data)
+	assert.NilError(t, err)
+	assert.Assert(t, src2.Oci != nil)
+	assert.Equal(t, src2.Oci.Repo, "myorg/kcl-templates/utils")
+	assert.Equal(t, src2.Oci.Tag, "0.4.0")
+	assert.Equal(t, src2.Oci.Reg, "")
+	assert.Equal(t, src2.Oci.RegFromEnv, true)
+
+	// Re-marshal: should produce the same string
+	marshaled2 := src2.MarshalTOML()
+	assert.Equal(t, marshaled, marshaled2)
+}
+
+// TestFromStringHostlessMarksRegFromEnv verifies that parsing an oci:///path URL
+// (e.g. from --oci flag) sets RegFromEnv when host is empty.
+func TestFromStringHostlessMarksRegFromEnv(t *testing.T) {
+	oci := &Oci{}
+	err := oci.FromString("oci:///myorg/kcl-templates/utils")
+	assert.NilError(t, err)
+	assert.Equal(t, oci.Reg, "")
+	assert.Equal(t, oci.Repo, "myorg/kcl-templates/utils")
+	assert.Equal(t, oci.RegFromEnv, true)
+}
+
+// TestFromStringFullUrlDoesNotMarkRegFromEnv verifies that a full oci://host/repo
+// URL does NOT set RegFromEnv.
+func TestFromStringFullUrlDoesNotMarkRegFromEnv(t *testing.T) {
+	oci := &Oci{}
+	err := oci.FromString("oci://ghcr.io/kcl-lang/helloworld")
+	assert.NilError(t, err)
+	assert.Equal(t, oci.Reg, "ghcr.io")
+	assert.Equal(t, oci.Repo, "kcl-lang/helloworld")
+	assert.Equal(t, oci.RegFromEnv, false)
+}

--- a/pkg/package/test_data/test_oci_url/marshal_hostless/kcl_mod_bk/kcl.mod
+++ b/pkg/package/test_data/test_oci_url/marshal_hostless/kcl_mod_bk/kcl.mod
@@ -1,0 +1,7 @@
+[package]
+name = "marshal_hostless"
+edition = "v0.12.3"
+version = "0.0.1"
+
+[dependencies]
+oci_pkg = { repo = "myorg/kcl-templates/oci_pkg", tag = "0.0.1", version = "0.0.1" }

--- a/pkg/package/test_data/test_oci_url/unmarshal_hostless/kcl.mod
+++ b/pkg/package/test_data/test_oci_url/unmarshal_hostless/kcl.mod
@@ -1,0 +1,7 @@
+[package]
+name = "unmarshal_hostless"
+edition = "v0.12.3"
+version = "0.0.1"
+
+[dependencies]
+oci_pkg_name = { repo = "myorg/kcl-templates/helloworld", tag = "0.0.1", version = "0.0.1" }

--- a/pkg/package/toml.go
+++ b/pkg/package/toml.go
@@ -286,7 +286,18 @@ func (dep *Dependencies) MarshalLockTOML() (string, error) {
 		if !ok {
 			break
 		}
-		marshaledDeps[depKey] = dep
+		// For host-less OCI dependencies (registry resolved from KPM_REG at runtime),
+		// clear Reg before writing so that reg,omitempty omits it from the lock.
+		// This produces a single lock file valid across all registry accounts.
+		if dep.Source.Oci != nil && dep.Source.Oci.RegFromEnv {
+			depCopy := dep
+			ociCopy := *dep.Source.Oci
+			ociCopy.Reg = ""
+			depCopy.Source.Oci = &ociCopy
+			marshaledDeps[depKey] = depCopy
+		} else {
+			marshaledDeps[depKey] = dep
+		}
 	}
 
 	lockDepdenciesUI := DependenciesUI{
@@ -320,7 +331,13 @@ func (dep *Dependencies) UnmarshalLockTOML(data string) error {
 	sort.Strings(keys)
 
 	for _, k := range keys {
-		dep.Deps.Set(k, lockDepdenciesUI.Deps[k])
+		d := lockDepdenciesUI.Deps[k]
+		// Restore the RegFromEnv sentinel for host-less entries (no reg in the lock)
+		// so that subsequent marshal operations continue to emit them as host-less.
+		if d.Source.Oci != nil && d.Source.Oci.Reg == "" && d.Source.Oci.Repo != "" {
+			d.Source.Oci.RegFromEnv = true
+		}
+		dep.Deps.Set(k, d)
 	}
 
 	return nil

--- a/pkg/package/toml_test.go
+++ b/pkg/package/toml_test.go
@@ -379,3 +379,169 @@ func TestUnMarshalRename(t *testing.T) {
 	assert.Equal(t, modfile.Dependencies.Deps.GetOrDefault("newpkg", TestPkgDependency).Oci.Repo, "kcl-lang/helloworld")
 	assert.Equal(t, modfile.Dependencies.Deps.GetOrDefault("newpkg", TestPkgDependency).Oci.Tag, "0.1.4")
 }
+
+// TestUnMarshalHostlessOciUrl verifies that a `repo = "..."` entry in kcl.mod
+// is parsed into an Oci with RegFromEnv=true, so that even after
+// fillDepsInfoWithSettings fills Reg with the default registry, the dep is still
+// marshaled back as host-less (`repo = "..."`).
+func TestUnMarshalHostlessOciUrl(t *testing.T) {
+	testDataDir := getTestDir("test_oci_url")
+
+	modfile, err := LoadModFile(filepath.Join(testDataDir, "unmarshal_hostless"))
+	assert.Equal(t, err, nil)
+	assert.Equal(t, modfile.Dependencies.Deps.Len(), 1)
+
+	dep := modfile.Dependencies.Deps.GetOrDefault("oci_pkg_name", TestPkgDependency)
+	assert.Equal(t, dep.Name, "oci_pkg_name")
+	assert.NotNil(t, dep.Source.Oci, "expected Oci source")
+	// RegFromEnv=true is preserved even after fillDepsInfoWithSettings fills Reg
+	// from the default registry.  The Reg value itself may be non-empty at this
+	// point; what matters is that RegFromEnv marks the dep as originally host-less.
+	assert.Equal(t, dep.Source.Oci.RegFromEnv, true)
+	assert.Equal(t, dep.Source.Oci.Repo, "myorg/kcl-templates/helloworld")
+	assert.Equal(t, dep.Source.Oci.Tag, "0.0.1")
+
+	// Even with Reg filled in by settings, marshaling must produce the host-less form.
+	marshaled := dep.Source.MarshalTOML()
+	assert.True(t, strings.Contains(marshaled, `repo = "myorg/kcl-templates/helloworld"`),
+		"marshal output should use repo key, got: %s", marshaled)
+	assert.False(t, strings.Contains(marshaled, "oci = "),
+		"marshal output must not contain full oci URL for host-less dep, got: %s", marshaled)
+}
+
+// TestMarshalHostlessOciUrl verifies that a host-less OCI dependency is written
+// back to kcl.mod using `repo = "..."` syntax and round-trips correctly.
+func TestMarshalHostlessOciUrl(t *testing.T) {
+	testDataDir := getTestDir("test_oci_url")
+
+	expectPkgPath := filepath.Join(testDataDir, "marshal_hostless", "kcl_mod_bk")
+	gotPkgPath := filepath.Join(testDataDir, "marshal_hostless", "kcl_mod_tmp")
+
+	expect, err := LoadModFile(expectPkgPath)
+	assert.Equal(t, err, nil)
+
+	err = os.MkdirAll(gotPkgPath, 0755)
+	assert.Equal(t, err, nil)
+	gotFile, _ := os.Create(filepath.Join(gotPkgPath, "kcl.mod"))
+
+	defer func() {
+		err = gotFile.Close()
+		assert.Equal(t, err, nil)
+		err = os.RemoveAll(gotPkgPath)
+		assert.Equal(t, err, nil)
+	}()
+
+	modfile := ModFile{
+		Pkg: Package{
+			Name:    "marshal_hostless",
+			Edition: "v0.12.3",
+			Version: "0.0.1",
+		},
+		Dependencies: Dependencies{
+			orderedmap.NewOrderedMap[string, Dependency](),
+		},
+	}
+
+	hostlessDep := Dependency{
+		Name:     "oci_pkg",
+		FullName: "oci_pkg_0.0.1",
+		Version:  "0.0.1",
+		Source: downloader.Source{
+			ModSpec: &downloader.ModSpec{
+				Name:    "oci_pkg",
+				Version: "0.0.1",
+			},
+			Oci: &downloader.Oci{
+				Repo:       "myorg/kcl-templates/oci_pkg",
+				Tag:        "0.0.1",
+				RegFromEnv: true,
+			},
+		},
+	}
+
+	modfile.Dependencies.Deps.Set("oci_pkg_0.0.1", hostlessDep)
+
+	got_data := modfile.MarshalTOML()
+	_, err = gotFile.WriteString(got_data)
+	assert.Equal(t, err, nil)
+
+	got := ModFile{}
+	err = got.LoadModFile(filepath.Join(gotPkgPath, "kcl.mod"))
+	assert.Equal(t, err, nil)
+
+	assert.Equal(t, expect.Pkg.Name, got.Pkg.Name)
+	assert.Equal(t, expect.Pkg.Edition, got.Pkg.Edition)
+	assert.Equal(t, expect.Pkg.Version, got.Pkg.Version)
+	assert.Equal(t, expect.Dependencies.Deps.Len(), got.Dependencies.Deps.Len())
+
+	gotDep := got.Dependencies.Deps.GetOrDefault("oci_pkg", TestPkgDependency)
+	assert.NotNil(t, gotDep.Source.Oci, "expected Oci source after round-trip")
+	// After LoadModFile → fillDepsInfoWithSettings, Reg may be non-empty.
+	// What must be preserved is RegFromEnv=true (dep was originally host-less).
+	assert.Equal(t, gotDep.Source.Oci.RegFromEnv, true)
+	assert.Equal(t, gotDep.Source.Oci.Repo, "myorg/kcl-templates/oci_pkg")
+	assert.Equal(t, gotDep.Source.Oci.Tag, "0.0.1")
+	// Re-marshal must be host-less.
+	assert.Equal(t, expect.Dependencies.Deps.GetOrDefault("oci_pkg", TestPkgDependency).Source.Oci.RegFromEnv,
+		gotDep.Source.Oci.RegFromEnv)
+}
+
+// TestMarshalLockTOMLHostless verifies that a host-less OCI dependency is written
+// to kcl.mod.lock without the `reg` key (omitted via omitempty), keeping a single
+// lock file valid across multiple registry accounts.
+func TestMarshalLockTOMLHostless(t *testing.T) {
+	hostlessDep := Dependency{
+		Name:     "MyHostlessOciKcl",
+		FullName: "MyHostlessOciKcl_0.0.1",
+		Version:  "0.0.1",
+		Sum:      "abc123",
+		Source: downloader.Source{
+			Oci: &downloader.Oci{
+				Repo:       "myorg/kcl-templates/utils",
+				Tag:        "0.0.1",
+				RegFromEnv: true,
+			},
+		},
+	}
+
+	// Simulate Reg temporarily filled by resolution (should not be persisted)
+	hostlessDep.Source.Oci.Reg = "672819064798.dkr.ecr.eu-west-1.amazonaws.com"
+
+	deps := Dependencies{
+		orderedmap.NewOrderedMap[string, Dependency](),
+	}
+	deps.Deps.Set(hostlessDep.Name, hostlessDep)
+
+	tomlStr, err := deps.MarshalLockTOML()
+	assert.Equal(t, err, nil)
+	assert.False(t, strings.Contains(tomlStr, "reg ="), "lock must not contain 'reg =' for a host-less dependency")
+	assert.True(t, strings.Contains(tomlStr, `repo = "myorg/kcl-templates/utils"`), "lock must contain repo")
+	assert.True(t, strings.Contains(tomlStr, `oci_tag = "0.0.1"`), "lock must contain oci_tag")
+	assert.True(t, strings.Contains(tomlStr, `sum = "abc123"`), "lock must contain sum")
+}
+
+// TestUnmarshalLockTOMLHostlessRestoresRegFromEnv verifies that loading a lock
+// entry without `reg` sets RegFromEnv=true so subsequent writes remain host-less.
+func TestUnmarshalLockTOMLHostlessRestoresRegFromEnv(t *testing.T) {
+	lockData := `[dependencies]
+  [dependencies.MyHostlessOciKcl]
+    name = "MyHostlessOciKcl"
+    full_name = "MyHostlessOciKcl_0.0.1"
+    version = "0.0.1"
+    sum = "abc123"
+    repo = "myorg/kcl-templates/utils"
+    oci_tag = "0.0.1"
+`
+	deps := Dependencies{
+		orderedmap.NewOrderedMap[string, Dependency](),
+	}
+	err := deps.UnmarshalLockTOML(lockData)
+	assert.Equal(t, err, nil)
+
+	dep := deps.Deps.GetOrDefault("MyHostlessOciKcl", TestPkgDependency)
+	assert.NotNil(t, dep.Source.Oci)
+	assert.Equal(t, dep.Source.Oci.Reg, "")
+	assert.Equal(t, dep.Source.Oci.RegFromEnv, true)
+	assert.Equal(t, dep.Source.Oci.Repo, "myorg/kcl-templates/utils")
+	assert.Equal(t, dep.Source.Oci.Tag, "0.0.1")
+}


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y (#739)

#### 2. What is the scope of this PR (e.g. component or file name):

`pkg/downloader/source.go`, `pkg/downloader/toml.go`, `pkg/package/toml.go`

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

**Host-less OCI dependencies (`repo = "..."` syntax)**

KPM previously required OCI dependencies to be declared with a full registry URL:

```toml
[dependencies]
my_pkg = { oci = "oci://ghcr.io/myorg/my_pkg", tag = "0.1.0" }
```

This PR adds support for a host-less form where the registry is resolved at runtime from `KPM_REG` / `DefaultOciRegistry`:

```toml
[dependencies]
my_pkg = { repo = "myorg/my_pkg", tag = "0.1.0" }
```

The core problem was that KPM temporarily fills `Oci.Reg` during resolution for the network call, then serializes the struct back to `kcl.mod` — silently replacing the user's host-less declaration with a fully-qualified URL that encodes a registry that may be environment-specific (e.g. an AWS ECR account ID). This breaks portability across environments.

The fix introduces a `RegFromEnv bool` sentinel field (tagged `toml:"-"` so it is never persisted) on `Oci`. It is set when the source is parsed without a host, and the marshal path checks it first — ensuring that even after `Reg` has been temporarily filled, the host-less form is written back to `kcl.mod` and `kcl.mod.lock`.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y

All existing `oci = "oci://..."` declarations continue to work unchanged. The new `repo = "..."` key is additive. The `RegFromEnv` field uses `toml:"-"` so it does not affect any serialized format.

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

New unit tests added:

- `pkg/downloader/toml_test.go` — `TestOciHostlessMarshal`, `TestOciFullUrlMarshal` (regression), `TestOciShortNameMarshal` (regression), `TestOciHostlessUnmarshal`, `TestSourceHostlessUnmarshal`, `TestOciHostlessMarshalRoundTrip`, `TestFromStringHostlessMarksRegFromEnv`, `TestFromStringFullUrlDoesNotMarkRegFromEnv`
- `pkg/package/toml_test.go` — `TestUnMarshalHostlessOciUrl`, `TestMarshalHostlessOciUrl`
- `pkg/oci/auth_cache_test.go` — `TestNewAuthCacheDefaultBehavior`
