### PR TITLE
feat(oci): host-less dependencies being honored in all execution paths

### DIFF
--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -241,6 +241,12 @@ func (d *OciDownloader) LatestVersion(opts *DownloadOptions) (string, error) {
 		return "", errors.New("oci source is nil")
 	}
 
+	// Host-less OCI dependency: resolve the registry host from
+	// KPM_REG / DefaultOciRegistry when it was not declared in the source.
+	if len(ociSource.Reg) == 0 {
+		ociSource.Reg = opts.Settings.DefaultOciRegistry()
+	}
+
 	repoPath := utils.JoinPath(ociSource.Reg, ociSource.Repo)
 
 	var cred *remoteauth.Credential
@@ -388,6 +394,12 @@ func (d *OciDownloader) Download(opts *DownloadOptions) error {
 	}
 
 	localPath := opts.LocalPath
+
+	// Host-less OCI dependency: resolve the registry host from
+	// KPM_REG / DefaultOciRegistry when it was not declared in the source.
+	if len(ociSource.Reg) == 0 {
+		ociSource.Reg = opts.Settings.DefaultOciRegistry()
+	}
 
 	repoPath := utils.JoinPath(ociSource.Reg, ociSource.Repo)
 

--- a/pkg/visitor/visitor.go
+++ b/pkg/visitor/visitor.go
@@ -129,6 +129,10 @@ func (rv *RemoteVisitor) Visit(s *downloader.Source, v visitFunc) error {
 			Repo: utils.JoinPath(rv.Settings.DefaultOciRepo(), s.ModSpec.Name),
 			Tag:  s.ModSpec.Version,
 		}
+	} else if s.Oci != nil && len(s.Oci.Reg) == 0 {
+		// Host-less OCI dependency (e.g. `repo = "org/path/pkg"` in kcl.mod):
+		// resolve the registry host from KPM_REG / DefaultOciRegistry at runtime.
+		s.Oci.Reg = rv.Settings.DefaultOciRegistry()
 	}
 
 	var cacheFullPath string

--- a/pkg/visitor/visitor_test.go
+++ b/pkg/visitor/visitor_test.go
@@ -101,6 +101,79 @@ func TestVisitPkgRemote(t *testing.T) {
 	}
 }
 
+// TestVisitPkgRemoteHostless verifies that a host-less OCI dependency
+// (`repo = "..."` in kcl.mod, no registry host) resolves the registry host
+// from KPM_REG at runtime instead of failing with "hostName is empty".
+func TestVisitPkgRemoteHostless(t *testing.T) {
+	oldReg := os.Getenv("KPM_REG")
+	err := os.Setenv("KPM_REG", "ghcr.io")
+	assert.NilError(t, err)
+	defer func() {
+		_ = os.Setenv("KPM_REG", oldReg)
+	}()
+
+	var buf bytes.Buffer
+	remotePkgVisitor := RemoteVisitor{
+		PkgVisitor: &PkgVisitor{
+			LogWriter: &buf,
+			Settings:  settings.GetSettings(),
+		},
+		Downloader: &downloader.DepDownloader{},
+	}
+
+	source, err := downloader.NewSourceFromStr("oci:///kcl-lang/helloworld?tag=0.1.2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, source.Oci.Reg, "")
+	assert.Equal(t, source.Oci.RegFromEnv, true)
+
+	err = remotePkgVisitor.Visit(source, func(pkg *pkg.KclPkg) error {
+		assert.Equal(t, pkg.GetPkgName(), "helloworld")
+		assert.Equal(t, pkg.GetPkgVersion(), "0.1.2")
+		return nil
+	})
+	assert.NilError(t, err)
+}
+
+// TestVisitPkgRemoteHostlessNoRegistryConfigured verifies that a host-less OCI
+// dependency (no host in the URI) legitimately fails when there is no KPM_REG
+// env var and no default registry configured, instead of silently resolving
+// to some unintended host.
+func TestVisitPkgRemoteHostlessNoRegistryConfigured(t *testing.T) {
+	oldReg := os.Getenv("KPM_REG")
+	err := os.Unsetenv("KPM_REG")
+	assert.NilError(t, err)
+	defer func() {
+		_ = os.Setenv("KPM_REG", oldReg)
+	}()
+
+	// Start from the real settings (valid CredentialsFile path) but with no
+	// default registry configured, simulating a fresh environment with no
+	// KPM_REG and no `kpm.json` default.
+	noRegSettings := *settings.GetSettings()
+	noRegSettings.Conf.DefaultOciRegistry = ""
+
+	var buf bytes.Buffer
+	remotePkgVisitor := RemoteVisitor{
+		PkgVisitor: &PkgVisitor{
+			LogWriter: &buf,
+			Settings:  &noRegSettings,
+		},
+		Downloader: &downloader.DepDownloader{},
+	}
+
+	source, err := downloader.NewSourceFromStr("oci:///kcl-lang/helloworld?tag=0.1.2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, source.Oci.Reg, "")
+	assert.Equal(t, source.Oci.RegFromEnv, true)
+
+	err = remotePkgVisitor.Visit(source, func(pkg *pkg.KclPkg) error { return nil })
+	assert.Error(t, err, "hostName is empty")
+}
+
 func TestVisitedSpace(t *testing.T) {
 	var buf bytes.Buffer
 	remotePkgVisitor := RemoteVisitor{


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y (#739)

#### 2. What is the scope of this PR (e.g. component or file name):

`pkg/downloader/source.go`, `pkg/downloader/toml.go`, `pkg/package/toml.go`

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

**Host-less OCI dependencies (`repo = "..."` syntax)**

KPM previously required OCI dependencies to be declared with a full registry URL:

```toml
[dependencies]
my_pkg = { oci = "oci://ghcr.io/myorg/my_pkg", tag = "0.1.0" }
```

This PR adds support for a host-less form where the registry is resolved at runtime from `KPM_REG` / `DefaultOciRegistry`:

```toml
[dependencies]
my_pkg = { repo = "myorg/my_pkg", tag = "0.1.0" }
```

The core problem was that KPM temporarily fills `Oci.Reg` during resolution for the network call, then serializes the struct back to `kcl.mod` — silently replacing the user's host-less declaration with a fully-qualified URL that encodes a registry that may be environment-specific (e.g. an AWS ECR account ID). This breaks portability across environments.

The fix introduces a `RegFromEnv bool` sentinel field (tagged `toml:"-"` so it is never persisted) on `Oci`. It is set when the source is parsed without a host, and the marshal path checks it first — ensuring that even after `Reg` has been temporarily filled, the host-less form is written back to `kcl.mod` and `kcl.mod.lock`.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y

All existing `oci = "oci://..."` declarations continue to work unchanged. The new `repo = "..."` key is additive. The `RegFromEnv` field uses `toml:"-"` so it does not affect any serialized format.

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

New unit tests added:

- `pkg/downloader/toml_test.go` — `TestOciHostlessMarshal`, `TestOciFullUrlMarshal` (regression), `TestOciShortNameMarshal` (regression), `TestOciHostlessUnmarshal`, `TestSourceHostlessUnmarshal`, `TestOciHostlessMarshalRoundTrip`, `TestFromStringHostlessMarksRegFromEnv`, `TestFromStringFullUrlDoesNotMarkRegFromEnv`
- `pkg/package/toml_test.go` — `TestUnMarshalHostlessOciUrl`, `TestMarshalHostlessOciUrl`
- `pkg/oci/auth_cache_test.go` — `TestNewAuthCacheDefaultBehavior`
