### PR TITLE
fix(oci): fallback to docker credentials file

### DIFF
--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -427,7 +427,12 @@ func loadCredential(hostName string, settings *settings.Settings) (*remoteauth.C
 		return nil, err
 	}
 
-	cred, err := store.Get(context.Background(), hostName)
+	dockerStore, err := credentials.NewStoreFromDocker(credentials.StoreOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	cred, err := credentials.NewStoreWithFallbacks(store, dockerStore).Get(context.Background(), hostName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
PR #700 introduced an unwanted regression. It removed the [fallback to the docker credentials file](https://github.com/kcl-lang/kpm/pull/700/changes#diff-570aea5baf5f0e0b7f46b570a48f173e8858df3436f091fb61d2e3c745db6f0eR368) when it existed.

This PR ensures the same behavior as before in KPM while keeping the versions bumped in #700 