### PR TITLE
feat(client): validate required kcl.mod fields before push (#508)

### DIFF
--- a/pkg/client/push.go
+++ b/pkg/client/push.go
@@ -3,6 +3,7 @@ package client
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"kcl-lang.io/kpm/pkg/downloader"
 	"kcl-lang.io/kpm/pkg/errors"
@@ -79,6 +80,47 @@ func (c *KpmClient) fillDefaultPushOptions(ociOpt *opt.OciOptions, kMod *pkg.Kcl
 	}
 }
 
+// validatePushModFields ensures that the kcl.mod being pushed has the
+// minimum fields required to construct a meaningful OCI tag and repository
+// path. Push requests with an empty `name` or `version` would otherwise
+// produce silently-broken artifacts (a missing tag, an ambiguous path).
+//
+// Refs: kpm-project issue #508.
+func validatePushModFields(kMod *pkg.KclPkg) error {
+	if kMod == nil {
+		return reporter.NewErrorEvent(
+			reporter.InvalidKclPkg,
+			nil,
+			"kcl.mod is not loaded; nothing to push.",
+		)
+	}
+
+	name := strings.TrimSpace(kMod.GetPkgName())
+	version := strings.TrimSpace(kMod.GetPkgTag())
+
+	switch {
+	case name == "" && version == "":
+		return reporter.NewErrorEvent(
+			reporter.InvalidKclPkg,
+			nil,
+			"kcl.mod is missing required fields `[package].name` and `[package].version`. Both must be set before pushing to an OCI registry.",
+		)
+	case name == "":
+		return reporter.NewErrorEvent(
+			reporter.InvalidKclPkg,
+			nil,
+			"kcl.mod is missing required field `[package].name`. Set it before pushing to an OCI registry.",
+		)
+	case version == "":
+		return reporter.NewErrorEvent(
+			reporter.InvalidKclPkg,
+			nil,
+			"kcl.mod is missing required field `[package].version`. Set it before pushing to an OCI registry.",
+		)
+	}
+	return nil
+}
+
 // Push will push a kcl package to a registry.
 func (c *KpmClient) Push(opts ...PushOption) error {
 	pushOpts := &PushOptions{}
@@ -94,6 +136,13 @@ func (c *KpmClient) Push(opts ...PushOption) error {
 	)
 
 	if err != nil {
+		return err
+	}
+
+	// Refs: issue #508. Reject kcl.mod files missing the minimum identity
+	// fields before any network I/O so the user sees a clear local error
+	// rather than a half-pushed artifact.
+	if err := validatePushModFields(kMod); err != nil {
 		return err
 	}
 

--- a/pkg/client/push_test.go
+++ b/pkg/client/push_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -216,6 +217,96 @@ func TestPushForceOption(t *testing.T) {
 
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, opts.Force, "Force option should be set to %v", tt.expected)
+		})
+	}
+}
+
+// TestValidatePushModFields covers the field validation added for #508.
+// The validator should reject kcl.mod files that are missing the minimum
+// identity fields needed to construct a meaningful OCI tag/repository path.
+func TestValidatePushModFields(t *testing.T) {
+	tests := []struct {
+		name        string
+		pkg         *pkg.KclPkg
+		wantErr     bool
+		wantSubstr  string
+	}{
+		{
+			name: "valid name and version",
+			pkg: &pkg.KclPkg{
+				ModFile: pkg.ModFile{
+					Pkg: pkg.Package{Name: "my-pkg", Version: "0.1.0"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:       "nil kcl.mod",
+			pkg:        nil,
+			wantErr:    true,
+			wantSubstr: "kcl.mod is not loaded",
+		},
+		{
+			name: "missing name only",
+			pkg: &pkg.KclPkg{
+				ModFile: pkg.ModFile{Pkg: pkg.Package{Version: "0.1.0"}},
+			},
+			wantErr:    true,
+			wantSubstr: "[package].name",
+		},
+		{
+			name: "missing version only",
+			pkg: &pkg.KclPkg{
+				ModFile: pkg.ModFile{Pkg: pkg.Package{Name: "my-pkg"}},
+			},
+			wantErr:    true,
+			wantSubstr: "[package].version",
+		},
+		{
+			name: "missing both",
+			pkg: &pkg.KclPkg{
+				ModFile: pkg.ModFile{Pkg: pkg.Package{}},
+			},
+			wantErr:    true,
+			wantSubstr: "name",
+		},
+		{
+			name: "whitespace-only name is rejected",
+			pkg: &pkg.KclPkg{
+				ModFile: pkg.ModFile{Pkg: pkg.Package{Name: "   ", Version: "0.1.0"}},
+			},
+			wantErr:    true,
+			wantSubstr: "[package].name",
+		},
+		{
+			name: "whitespace-only version is rejected",
+			pkg: &pkg.KclPkg{
+				ModFile: pkg.ModFile{Pkg: pkg.Package{Name: "my-pkg", Version: "\t"}},
+			},
+			wantErr:    true,
+			wantSubstr: "[package].version",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePushModFields(tt.pkg)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				ev, ok := err.(*reporter.KpmEvent)
+				if !ok {
+					t.Fatalf("expected *reporter.KpmEvent, got %T", err)
+				}
+				if ev.Type() != reporter.InvalidKclPkg {
+					t.Errorf("expected event type InvalidKclPkg, got %v", ev.Type())
+				}
+				if tt.wantSubstr != "" && !strings.Contains(ev.Error(), tt.wantSubstr) {
+					t.Errorf("expected substring %q in error, got %q", tt.wantSubstr, ev.Error())
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

`kcl mod push` would build an OCI tag and repository path from `kcl.mod.Pkg.Name` and `Version` without checking that either field was non-empty. A `kcl.mod` with an empty name or version produced a silently-broken artifact on the registry (ambiguous path, missing tag, or an OCI 404 from consumers trying to pull by tag).

This change adds a pre-flight validator in `Push()` that rejects kcl.mod files missing `[package].name` or `[package].version` **before any network I/O**, so users see a clear local error pointing at the exact field that needs to be set.

## Changes

- `pkg/client/push.go`:
  - New `validatePushModFields(kMod)` helper.
  - `Push()` invokes the validator immediately after `LoadKclPkgWithOpts`.
  - Returns `*reporter.KpmEvent` of type `InvalidKclPkg` so the existing event-reporting pipeline renders the message and existing log-level filtering (`KPM_LOG_LEVEL`, see #124) applies.
  - Whitespace-only values are also rejected — they would otherwise round-trip past an empty-string check.
  - Distinct messages for "both missing", "name missing", "version missing" to keep the error actionable.
- `pkg/client/push_test.go`: new `TestValidatePushModFields` table-driven test covering valid input, nil, each missing field, both missing, and whitespace-only values. No network required.

Closes #508.

## Test plan

- [x] `go test -run TestValidatePushModFields ./pkg/client/...` green locally.
- [ ] CI on the branch (the `test/e2e` suite still needs the mock registry per #621 and is unrelated to this change).