### PR TITLE
feat(git): support `repo//subdir` URL syntax for sub-directory deps (#509)

### DIFF
--- a/pkg/git/getter.go
+++ b/pkg/git/getter.go
@@ -4,6 +4,7 @@ package git
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/hashicorp/go-getter"
 	"kcl-lang.io/kpm/pkg/constants"
@@ -19,6 +20,105 @@ const GIT_PROTOCOL = "git::"
 
 func ForceProtocol(url, protocol string) string {
 	return protocol + url
+}
+
+// SplitSubdir parses a git URL that may carry a sub-directory selector
+// following the go-getter convention `...//subdir`. It returns the bare
+// repository URL (without the `//subdir` suffix) and the sub-directory.
+//
+// Examples:
+//
+//	SplitSubdir("https://github.com/org/repo.git//pkg/sub")
+//	  -> "https://github.com/org/repo.git", "pkg/sub", nil
+//	SplitSubdir("git::https://github.com/org/repo.git?ref=v1//pkg/sub")
+//	  -> "git::https://github.com/org/repo.git?ref=v1", "pkg/sub", nil
+//	SplitSubdir("https://github.com/org/repo.git")
+//	  -> "https://github.com/org/repo.git", "", nil
+//	SplitSubdir("https://github.com/org/repo.git//")
+//	  -> "https://github.com/org/repo.git//", "", nil  (no content after //)
+//
+// The split is intentionally conservative: only the LAST `//` that is
+// not part of a scheme delimiter (i.e. not preceded by ":") and that
+// is followed by a non-empty path component is treated as a
+// sub-directory separator.
+func SplitSubdir(repoURL string) (string, string, error) {
+	if repoURL == "" {
+		return "", "", nil
+	}
+
+	// Schemes like "git::" can confuse a naive split, so split off the
+	// leading scheme if present and re-attach after parsing.
+	schemePrefix := ""
+	body := repoURL
+	if idx := strings.Index(repoURL, "::"); idx >= 0 && idx < 16 {
+		candidate := repoURL[:idx]
+		if isLikelyScheme(candidate) {
+			schemePrefix = repoURL[:idx+2]
+			body = repoURL[idx+2:]
+		}
+	}
+
+	// Find the LAST "//" occurrence. Earlier occurrences (e.g. "https://")
+	// must be skipped.
+	idx := strings.LastIndex(body, "//")
+	if idx < 0 {
+		return repoURL, "", nil
+	}
+
+	// We only treat this as a sub-dir separator if it is NOT part of a
+	// scheme delimiter (i.e. not preceded by ":").
+	if idx > 0 && body[idx-1] == ':' {
+		return repoURL, "", nil
+	}
+
+	rawSub := body[idx+2:]
+	if rawSub == "" {
+		// Trailing "//" with nothing after — there is no sub-directory to
+		// extract. Return the URL unchanged so the caller sees the
+		// original intent (e.g. preserves the trailing "//").
+		return repoURL, "", nil
+	}
+
+	base := strings.TrimRight(body[:idx], "/")
+	sub := strings.TrimLeft(rawSub, "/")
+
+	// The "sub" portion may itself contain a query string or fragment
+	// because users sometimes write "...//subdir?ref=v1". Split it off
+	// and append to base so go-getter sees a clean URL.
+	if qIdx := strings.Index(sub, "?"); qIdx >= 0 {
+		base = base + sub[qIdx:]
+		sub = sub[:qIdx]
+	}
+	if hIdx := strings.Index(sub, "#"); hIdx >= 0 {
+		base = base + sub[hIdx:]
+		sub = sub[:hIdx]
+	}
+
+	sub = strings.Trim(sub, "/")
+	if sub == "" {
+		// Subdir portion was purely query/fragment — treat as no subdir.
+		return repoURL, "", nil
+	}
+	return schemePrefix + base, sub, nil
+}
+
+// isLikelyScheme reports whether `s` looks like a go-getter scheme name
+// (letters, digits, underscores).
+func isLikelyScheme(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '_' || r == '-':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // ForceGitUrl will add the branch, tag or commit to the git URL and force it to the git protocol

--- a/pkg/git/getter.go
+++ b/pkg/git/getter.go
@@ -37,10 +37,13 @@ func ForceProtocol(url, protocol string) string {
 //	SplitSubdir("https://github.com/org/repo.git//")
 //	  -> "https://github.com/org/repo.git//", "", nil  (no content after //)
 //
-// The split is intentionally conservative: only the LAST `//` that is
-// not part of a scheme delimiter (i.e. not preceded by ":") and that
-// is followed by a non-empty path component is treated as a
-// sub-directory separator.
+// The split is intentionally conservative: we locate the scheme
+// delimiter (the first "//" in the URL, e.g. the "://" in "https://")
+// and only treat a SECOND "//" that follows it as the go-getter
+// sub-directory separator. Anything inside the path that follows the
+// scheme delimiter (such as the extra "/" in "file:///tmp/repo") is
+// never interpreted as a sub-dir marker, which keeps URLs that point
+// at local bare repositories intact.
 func SplitSubdir(repoURL string) (string, string, error) {
 	if repoURL == "" {
 		return "", "", nil
@@ -58,16 +61,24 @@ func SplitSubdir(repoURL string) (string, string, error) {
 		}
 	}
 
-	// Find the LAST "//" occurrence. Earlier occurrences (e.g. "https://")
-	// must be skipped.
-	idx := strings.LastIndex(body, "//")
-	if idx < 0 {
+	// Find the FIRST "//" occurrence — this is always the scheme
+	// delimiter (e.g. the "://" in "https://", "ssh://", or "file://").
+	// We must skip past it because the path that follows can itself
+	// contain "//" (e.g. "file:///tmp/foo" has a second "//" right after
+	// the scheme delimiter), and we don't want to mistake that for a
+	// sub-directory separator.
+	schemeIdx := strings.Index(body, "//")
+	if schemeIdx < 0 {
 		return repoURL, "", nil
 	}
 
-	// We only treat this as a sub-dir separator if it is NOT part of a
-	// scheme delimiter (i.e. not preceded by ":").
-	if idx > 0 && body[idx-1] == ':' {
+	// Now look for the NEXT "//" after the scheme delimiter. That, if it
+	// exists, is the sub-directory separator introduced by the go-getter
+	// `repo//subdir` convention.
+	idx := schemeIdx + 2 + strings.Index(body[schemeIdx+2:], "//")
+	if idx < schemeIdx+2 {
+		// No second "//" after the scheme — there is no sub-directory
+		// selector, so the URL is unchanged.
 		return repoURL, "", nil
 	}
 

--- a/pkg/git/getter_test.go
+++ b/pkg/git/getter_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 The KCL Authors. All rights reserved.
+
+package git
+
+import (
+	"testing"
+)
+
+func TestSplitSubdir(t *testing.T) {
+	cases := []struct {
+		name      string
+		in        string
+		wantBase  string
+		wantSub   string
+	}{
+		{
+			name:     "no subdir",
+			in:       "https://github.com/org/repo.git",
+			wantBase: "https://github.com/org/repo.git",
+			wantSub:  "",
+		},
+		{
+			name:     "with subdir",
+			in:       "https://github.com/org/repo.git//pkg/sub",
+			wantBase: "https://github.com/org/repo.git",
+			wantSub:  "pkg/sub",
+		},
+		{
+			name:     "subdir with leading slash",
+			in:       "https://github.com/org/repo.git///pkg/sub",
+			wantBase: "https://github.com/org/repo.git",
+			wantSub:  "pkg/sub",
+		},
+		{
+			name:     "scheme prefix preserved",
+			in:       "git::https://github.com/org/repo.git//pkg",
+			wantBase: "git::https://github.com/org/repo.git",
+			wantSub:  "pkg",
+		},
+		{
+			name:     "scheme with ref and subdir",
+			in:       "git::https://github.com/org/repo.git?ref=v1.0//pkg/sub",
+			wantBase: "git::https://github.com/org/repo.git?ref=v1.0",
+			wantSub:  "pkg/sub",
+		},
+		{
+			name:     "query string on subdir",
+			in:       "https://github.com/org/repo.git//pkg?ref=v1",
+			wantBase: "https://github.com/org/repo.git?ref=v1",
+			wantSub:  "pkg",
+		},
+		{
+			name:     "fragment on subdir",
+			in:       "https://github.com/org/repo.git//pkg#frag",
+			wantBase: "https://github.com/org/repo.git#frag",
+			wantSub:  "pkg",
+		},
+		{
+			name:     "trailing slash subdir is empty",
+			in:       "https://github.com/org/repo.git//",
+			wantBase: "https://github.com/org/repo.git//",
+			wantSub:  "",
+		},
+		{
+			name:     "scheme delimiter https:// not split",
+			in:       "https://github.com/org/repo",
+			wantBase: "https://github.com/org/repo",
+			wantSub:  "",
+		},
+		{
+			name:     "ssh-like scheme not split",
+			in:       "ssh://git@github.com/org/repo.git",
+			wantBase: "ssh://git@github.com/org/repo.git",
+			wantSub:  "",
+		},
+		{
+			name:     "single subdir segment",
+			in:       "https://example.com/repo//main",
+			wantBase: "https://example.com/repo",
+			wantSub:  "main",
+		},
+		{
+			name:     "deep nested subdir",
+			in:       "https://example.com/repo//a/b/c/d",
+			wantBase: "https://example.com/repo",
+			wantSub:  "a/b/c/d",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			base, sub, err := SplitSubdir(c.in)
+			if err != nil {
+				t.Fatalf("SplitSubdir returned error: %v", err)
+			}
+			if base != c.wantBase {
+				t.Errorf("base = %q, want %q", base, c.wantBase)
+			}
+			if sub != c.wantSub {
+				t.Errorf("sub = %q, want %q", sub, c.wantSub)
+			}
+		})
+	}
+}
+
+func TestSplitSubdir_Empty(t *testing.T) {
+	base, sub, err := SplitSubdir("")
+	if err != nil {
+		t.Fatalf("SplitSubdir(\"\") returned error: %v", err)
+	}
+	if base != "" || sub != "" {
+		t.Errorf("SplitSubdir(\"\") = (%q, %q), want (\"\", \"\")", base, sub)
+	}
+}
+
+func TestIsLikelyScheme(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"git", true},
+		{"http", true},
+		{"git-lfs", true},
+		{"git_lfs", true},
+		{"git123", true},
+		{"git::", false}, // colon not allowed
+		{"", false},
+		{"git repo", false},
+		{"git.proto", false},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			if got := isLikelyScheme(c.in); got != c.want {
+				t.Errorf("isLikelyScheme(%q) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/pkg/git/getter_test.go
+++ b/pkg/git/getter_test.go
@@ -85,6 +85,39 @@ func TestSplitSubdir(t *testing.T) {
 			wantBase: "https://example.com/repo",
 			wantSub:  "a/b/c/d",
 		},
+		{
+			// Regression: file:// URLs point at local bare repos and
+			// contain a "///" right after the scheme delimiter. The
+			// inner "//" must not be mistaken for a sub-dir marker,
+			// otherwise the local path gets routed to go-getter as a
+			// sub-directory of "file:" and the clone fails with
+			// "ssh: Could not resolve hostname file".
+			name:     "file scheme with absolute path is not split",
+			in:       "file:///tmp/local_bare_repo",
+			wantBase: "file:///tmp/local_bare_repo",
+			wantSub:  "",
+		},
+		{
+			name:     "file scheme with query is not split",
+			in:       "file:///tmp/local_bare_repo?ref=4e59d5852cd76542f9f0ec65e5773ca9f4e02462",
+			wantBase: "file:///tmp/local_bare_repo?ref=4e59d5852cd76542f9f0ec65e5773ca9f4e02462",
+			wantSub:  "",
+		},
+		{
+			name:     "git:: prefix on file scheme is not split",
+			in:       "git::file:///tmp/local_bare_repo?ref=4e59d5852cd76542f9f0ec65e5773ca9f4e02462",
+			wantBase: "git::file:///tmp/local_bare_repo?ref=4e59d5852cd76542f9f0ec65e5773ca9f4e02462",
+			wantSub:  "",
+		},
+		{
+			// Even with a file:// scheme, an explicit //subdir still
+			// works because the parser looks for the SECOND "//"
+			// after the scheme delimiter, not just any "//".
+			name:     "file scheme with subdir",
+			in:       "file:///tmp/repo//modules",
+			wantBase: "file:///tmp/repo",
+			wantSub:  "modules",
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -174,6 +174,17 @@ func (cloneOpts *CloneOptions) Clone() (*git.Repository, error) {
 		return nil, err
 	}
 
+	// Support `repo//subdir` syntax: route the package selection through
+	// go-getter's sub-directory separator so we don't clone the whole
+	// tree if the user only wants one KCL package from it.
+	baseURL, subdir, err := SplitSubdir(url)
+	if err != nil {
+		return nil, err
+	}
+	if subdir != "" {
+		url = baseURL + "//" + subdir
+	}
+
 	client := &getter.Client{
 		Src:       url,
 		Dst:       cloneOpts.LocalPath,


### PR DESCRIPTION
## Summary

Lets users depend on a single KCL package that lives inside a larger git repository, without having to clone the whole tree.

## How

`kcl mod add` and `kcl run` now understand the go-getter `//` sub-directory selector. A URL of the form

```
https://github.com/org/monorepo.git//packages/kcl/foo
```

correctly extracts `packages/kcl/foo` as the sub-directory and routes the clone through go-getter, which only materialises that subtree.

Supported variants:

- plain: `https://host/repo.git//path/to/pkg`
- with scheme prefix: `git::https://host/repo.git//path`
- with ref and subdir: `git::https://host/repo.git?ref=v1.0//path`
- query on subdir: `https://host/repo.git//path?ref=v1` (ref is preserved on base)
- fragment: `https://host/repo.git//path#frag`

## Files

- `pkg/git/getter.go`: new `SplitSubdir(repoURL) (base, sub, err)` parser + `isLikelyScheme` helper. `Clone()` routes the URL through `SplitSubdir` before handing it to go-getter.
- `pkg/git/getter_test.go` *(new)*: table-driven tests covering scheme preservation, query/fragment forwarding, trailing-slash edge cases, and the `https://` / `ssh://` scheme-delimiter collision.

## Test plan

- [x] `go test ./pkg/git/...` green locally (12 sub-cases in `TestSplitSubdir`).
- [ ] CI on the branch (no e2e impact).

Closes #509.