### PR TITLE
feat(auth): refresh provider-minted OCI credentials on pull

### DIFF
--- a/pkg/auth/resolve.go
+++ b/pkg/auth/resolve.go
@@ -1,0 +1,78 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+
+	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/credentials"
+)
+
+// Resolver turns a registry hostname into an [auth.Credential] by first
+// consulting a ProviderStore (so non-credential flows like GCP Workload
+// Identity can mint fresh tokens on every call) and then falling back to
+// the ORAS credential store.
+//
+// Resolver is the [auth.CredentialFunc] ORAS uses inside the OCI client,
+// so it is invoked on every 401 retry — which is exactly when providers
+// that return short-lived tokens (GCP OAuth tokens, ~1h TTL) want to
+// mint a fresh credential.
+type Resolver struct {
+	// Providers maps host → provider name. nil is treated as an empty
+	// store (everything falls through to fallback).
+	Providers *ProviderStore
+	// Fallback is the ORAS credential store consulted when no provider
+	// is configured for the host. Must not be nil.
+	Fallback credentials.Store
+}
+
+// NewResolver builds a Resolver from the given sidecar path and ORAS
+// fallback store. It is the typical wiring inside the OCI client.
+func NewResolver(providers *ProviderStore, fallback credentials.Store) *Resolver {
+	return &Resolver{
+		Providers: providers,
+		Fallback:  fallback,
+	}
+}
+
+// Resolve implements [auth.CredentialFunc]. ORAS calls it with the host
+// of the request; we route through the configured provider when one is
+// registered, otherwise fall back to the ORAS credential store.
+//
+// The returned credential is whatever the provider or the ORAS store
+// gives us — the caller (ORAS) handles caching the resulting Bearer
+// token for the lifetime of the process. Provider implementations
+// therefore do not need their own TTL cache: every 401 that survives
+// the ORAS cache will re-enter this function and trigger a fresh mint.
+func (r *Resolver) Resolve(ctx context.Context, host string) (auth.Credential, error) {
+	if r == nil {
+		return auth.EmptyCredential, nil
+	}
+	if r.Providers != nil {
+		name, err := r.Providers.Get(host)
+		if err != nil {
+			return auth.Credential{}, fmt.Errorf("kpm auth: read provider store for %q: %w", host, err)
+		}
+		if name != "" {
+			p, err := ByName(name)
+			if err != nil {
+				return auth.Credential{}, fmt.Errorf("kpm auth: host %q mapped to provider %q: %w", host, name, err)
+			}
+			return p.Credential(ctx, host)
+		}
+	}
+	if r.Fallback == nil {
+		return auth.EmptyCredential, nil
+	}
+	cred, err := r.Fallback.Get(ctx, host)
+	if err != nil {
+		return auth.Credential{}, err
+	}
+	return cred, nil
+}
+
+// AsCredentialFunc returns the Resolver as an [auth.CredentialFunc] so
+// callers can pass it directly to ORAS. Mostly a convenience for tests.
+func (r *Resolver) AsCredentialFunc() auth.CredentialFunc {
+	return r.Resolve
+}

--- a/pkg/auth/resolve_test.go
+++ b/pkg/auth/resolve_test.go
@@ -1,0 +1,219 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	remoteauth "oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/credentials"
+)
+
+// newResolveFakeMetadata stands up an httptest server that mimics the
+// GCE metadata endpoint well enough for GCPProvider to mint a token.
+// It records the number of token mint calls so tests can assert that
+// Resolve() called the provider each time it was invoked.
+//
+// The fake is intentionally lightweight — only the two routes the
+// GCPProvider hits need to exist. Other paths return 404.
+func newResolveFakeMetadata(t *testing.T) (*httptest.Server, *int32) {
+	t.Helper()
+	var tokenCalls int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/computeMetadata/v1/instance/id", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Metadata-Flavor", "Google")
+		_, _ = w.Write([]byte("fake-instance"))
+	})
+	mux.HandleFunc("/computeMetadata/v1/instance/service-accounts/default/token", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&tokenCalls, 1)
+		w.Header().Set("Metadata-Flavor", "Google")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "ya29.test-token",
+			"expires_in":   3600,
+			"token_type":   "Bearer",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, &tokenCalls
+}
+
+// pointGCPAtFakeServer sets GCE_METADATA_HOST to host:port so the
+// default GCPProvider hits our httptest server instead of the real
+// metadata server.
+func pointGCPAtFakeServer(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse fake metadata URL: %v", err)
+	}
+	t.Setenv("GCE_METADATA_HOST", u.Host)
+}
+
+// TestResolver_NilSafe verifies that a nil Resolver behaves like ORAS's
+// EmptyCredential — ORAS treats that as "no auth for this host".
+func TestResolver_NilSafe(t *testing.T) {
+	var r *Resolver
+	cred, err := r.Resolve(context.Background(), "gcr.io")
+	if err != nil {
+		t.Fatalf("nil Resolve: %v", err)
+	}
+	if cred != remoteauth.EmptyCredential {
+		t.Fatalf("nil Resolve: got %+v, want EmptyCredential", cred)
+	}
+}
+
+// TestResolver_NoProviderConfigured verifies that with an empty
+// ProviderStore and a populated ORAS fallback, Resolve reads the
+// ORAS store.
+func TestResolver_NoProviderConfigured(t *testing.T) {
+	store := newMemStore(t)
+	if err := store.Put(context.Background(), "gcr.io", remoteauth.Credential{Username: "alice", Password: "secret"}); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	r := NewResolver(nil, store)
+	cred, err := r.Resolve(context.Background(), "gcr.io")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if cred.Username != "alice" || cred.Password != "secret" {
+		t.Fatalf("Resolve: got %+v, want alice/secret", cred)
+	}
+}
+
+// TestResolver_ProviderRoutedToCredentialFunc verifies that when the
+// ProviderStore maps a host to the built-in GCP provider, Resolve
+// calls GCPProvider.Credential() and returns its result instead of
+// touching the ORAS fallback.
+func TestResolver_ProviderRoutedToCredentialFunc(t *testing.T) {
+	srv, _ := newResolveFakeMetadata(t)
+	pointGCPAtFakeServer(t, srv)
+
+	store := newMemStore(t)
+	if err := store.Put(context.Background(), "gcr.io", remoteauth.Credential{Username: "alice", Password: "secret"}); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	ps := OpenProviderStore(filepath.Join(t.TempDir(), "providers.json"))
+	if err := ps.Set("gcr.io", "gcp"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	r := NewResolver(ps, store)
+	cred, err := r.Resolve(context.Background(), "gcr.io")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if cred.Username != "oauth2accesstoken" || cred.Password != "ya29.test-token" {
+		t.Fatalf("Resolve: got %+v, want GCP-minted token (provider should override ORAS store)", cred)
+	}
+}
+
+// TestResolver_ProviderMintCalledPerInvocation verifies that the
+// provider's Credential function is called every time Resolve is
+// invoked. This is what allows GCP tokens (~1h TTL) to be refreshed
+// without us owning the TTL cache: ORAS caches the *Bearer token* on
+// success, but when the cached token 401s, ORAS re-enters our
+// CredentialFunc, which mints fresh.
+func TestResolver_ProviderMintCalledPerInvocation(t *testing.T) {
+	srv, tokenCalls := newResolveFakeMetadata(t)
+	pointGCPAtFakeServer(t, srv)
+
+	ps := OpenProviderStore(filepath.Join(t.TempDir(), "providers.json"))
+	if err := ps.Set("gcr.io", "gcp"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	r := NewResolver(ps, newMemStore(t))
+	for i := 0; i < 5; i++ {
+		if _, err := r.Resolve(context.Background(), "gcr.io"); err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+	}
+	if got := atomic.LoadInt32(tokenCalls); got != 5 {
+		t.Fatalf("provider mints: got %d, want 5", got)
+	}
+}
+
+// TestResolver_ProviderMintErrorSurfaces verifies that when the
+// provider's Credential function errors, Resolve propagates it instead
+// of falling through to the ORAS store. This is important: if GCP is
+// down we want a clear "cannot mint" error, not silent use of an
+// unrelated credential.
+func TestResolver_ProviderMintErrorSurfaces(t *testing.T) {
+	// Server that returns 404 on every path → GCPProvider surfaces
+	// "not running on GCE/GKE" wrapped in ErrCredential.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	pointGCPAtFakeServer(t, srv)
+
+	ps := OpenProviderStore(filepath.Join(t.TempDir(), "providers.json"))
+	if err := ps.Set("gcr.io", "gcp"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	r := NewResolver(ps, newMemStore(t))
+	_, err := r.Resolve(context.Background(), "gcr.io")
+	if err == nil {
+		t.Fatalf("expected error from GCP provider outside GCE, got nil")
+	}
+	if !strings.Contains(err.Error(), "not running on GCE/GKE") {
+		t.Fatalf("error should mention GCE/GKE: %v", err)
+	}
+}
+
+// TestResolver_UnknownProviderReturnsError verifies that an entry in
+// the sidecar that points at a provider the current binary does not
+// know about is a clear configuration error, not silent fallback.
+func TestResolver_UnknownProviderReturnsError(t *testing.T) {
+	ps := OpenProviderStore(filepath.Join(t.TempDir(), "providers.json"))
+	if err := ps.Set("gcr.io", "does-not-exist"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	r := NewResolver(ps, newMemStore(t))
+	_, err := r.Resolve(context.Background(), "gcr.io")
+	if err == nil {
+		t.Fatalf("expected error from unknown provider, got nil")
+	}
+}
+
+// TestResolver_FallbackMissing verifies the contract for "host has no
+// provider and the ORAS store has no entry" — Resolve returns
+// EmptyCredential with no error, which ORAS treats as anonymous
+// access (try the public endpoint, fail with a 401 → public).
+func TestResolver_FallbackMissing(t *testing.T) {
+	r := NewResolver(nil, newMemStore(t))
+	cred, err := r.Resolve(context.Background(), "gcr.io")
+	if err != nil {
+		t.Fatalf("Resolve on empty fallback: %v", err)
+	}
+	if cred != remoteauth.EmptyCredential {
+		t.Fatalf("Resolve on empty fallback: got %+v, want EmptyCredential", cred)
+	}
+}
+
+// newMemStore returns an in-memory credentials.Store backed by a
+// per-test temp file so multiple tests don't collide.
+func newMemStore(t *testing.T) credentials.Store {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "oras-config.json")
+	s, err := credentials.NewStore(path, credentials.StoreOptions{
+		AllowPlaintextPut: true,
+	})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	return s
+}

--- a/pkg/auth/store.go
+++ b/pkg/auth/store.go
@@ -1,0 +1,193 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// ProviderStore persists a host → provider-name mapping in a small JSON
+// sidecar file so that `kpm login` (writer) and `kpm pull` (reader) can
+// share state about which OCI registries are owned by a non-static
+// credential provider (e.g. GCP Workload Identity).
+//
+// The sidecar lives next to the existing ORAS credential store at
+// `<kpm-home>/.kpm/config/providers.json`. ORAS itself does not read
+// this file — kpm consults it via Resolve() before falling back to the
+// ORAS store.
+//
+// Concurrency: safe for use from multiple goroutines. The store lazily
+// loads from disk on first access; writes re-serialise the map. There is
+// no cross-process locking — if two kpm processes run against the same
+// home at the same time, last writer wins. This matches ORAS's own
+// behaviour for the config.json it owns.
+type ProviderStore struct {
+	// path is the on-disk location of the sidecar file.
+	path string
+
+	// mu protects loaded, providers, and loadErr. It is held in write
+	// mode during Set/Delete/save and read mode during Get.
+	mu sync.RWMutex
+	// loaded records whether we've already attempted to read the file.
+	// If false and the file doesn't exist yet, the store is just an
+	// empty map.
+	loaded bool
+	// providers maps registry hostname → provider name (e.g. "gcp").
+	providers map[string]string
+	// loadErr is the sticky error from the first load attempt, if any.
+	// Subsequent Get/Set calls will surface it so callers see real I/O
+	// failures instead of silently treating the file as empty.
+	loadErr error
+}
+
+// providerStoreFile is the on-disk schema.
+//
+// We version the format so that future migrations are explicit. The
+// current version only has the Providers map.
+type providerStoreFile struct {
+	// Version is the schema version. Currently always 1.
+	Version int `json:"version"`
+	// Providers maps registry hostname → provider name.
+	Providers map[string]string `json:"providers"`
+}
+
+// currentProviderStoreVersion is the only version this codebase knows.
+const currentProviderStoreVersion = 1
+
+// OpenProviderStore returns a store backed by path. The file at path
+// is not read until the first Get/Set/Delete call. If the file does
+// not exist yet, the store behaves as empty until something is written.
+//
+// path is expected to point at a regular file path, not a directory.
+func OpenProviderStore(path string) *ProviderStore {
+	return &ProviderStore{
+		path:      path,
+		providers: map[string]string{},
+	}
+}
+
+// load reads the sidecar from disk if not already loaded. The caller
+// must hold s.mu (read or write).
+func (s *ProviderStore) load() error {
+	if s.loaded {
+		return s.loadErr
+	}
+	s.loaded = true
+
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// First-time use: leave providers empty and treat as
+			// loaded. We do NOT set loadErr here so that subsequent
+			// writes succeed even when no file exists yet.
+			return nil
+		}
+		s.loadErr = err
+		return err
+	}
+
+	var f providerStoreFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		s.loadErr = fmt.Errorf("kpm auth: parse %s: %w", s.path, err)
+		return s.loadErr
+	}
+
+	if f.Version != currentProviderStoreVersion {
+		s.loadErr = fmt.Errorf("kpm auth: %s: unsupported provider store version %d (want %d)", s.path, f.Version, currentProviderStoreVersion)
+		return s.loadErr
+	}
+
+	if f.Providers != nil {
+		s.providers = f.Providers
+	}
+	return nil
+}
+
+// save serialises the in-memory map to disk. Caller must hold s.mu in
+// write mode.
+func (s *ProviderStore) save() error {
+	f := providerStoreFile{
+		Version:   currentProviderStoreVersion,
+		Providers: s.providers,
+	}
+	data, err := json.MarshalIndent(&f, "", "  ")
+	if err != nil {
+		return fmt.Errorf("kpm auth: marshal provider store: %w", err)
+	}
+
+	// Atomic-ish write: ensure the parent directory exists, then
+	// write to a sibling temp file, fsync, rename. This avoids
+	// leaving a half-written file behind if kpm is killed mid-write.
+	if dir := filepath.Dir(s.path); dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("kpm auth: create %s: %w", dir, err)
+		}
+	}
+	tmpPath := s.path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o600); err != nil {
+		return fmt.Errorf("kpm auth: write %s: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, s.path); err != nil {
+		return fmt.Errorf("kpm auth: rename %s -> %s: %w", tmpPath, s.path, err)
+	}
+	return nil
+}
+
+// Get returns the provider name registered for host. The empty string
+// means "no provider configured" — the caller should fall back to the
+// ORAS credential store.
+//
+// The returned error is non-nil only if the sidecar exists but could
+// not be read or parsed. A missing sidecar is not an error.
+func (s *ProviderStore) Get(host string) (string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if err := s.load(); err != nil {
+		return "", err
+	}
+	return s.providers[host], nil
+}
+
+// Set records that host is owned by providerName. Calling Set with the
+// same host overwrites the previous provider. Set is the only operation
+// that creates the sidecar on disk; if the file does not exist yet,
+// Set creates it (and its parent directory).
+func (s *ProviderStore) Set(host, providerName string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.load(); err != nil {
+		return err
+	}
+
+	if s.providers[host] == providerName {
+		// No-op: already configured. Avoid touching the file
+		// unnecessarily so we don't disturb a concurrent reader.
+		return nil
+	}
+	s.providers[host] = providerName
+	return s.save()
+}
+
+// Delete removes the entry for host. It is a no-op (no error) if the
+// host is not currently registered, so callers can call Delete
+// unconditionally on logout.
+func (s *ProviderStore) Delete(host string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.load(); err != nil {
+		return err
+	}
+
+	if _, ok := s.providers[host]; !ok {
+		return nil
+	}
+	delete(s.providers, host)
+	return s.save()
+}

--- a/pkg/auth/store_test.go
+++ b/pkg/auth/store_test.go
@@ -1,0 +1,175 @@
+package auth
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// TestProviderStore_GetOnEmptyFile verifies that a missing sidecar
+// behaves as an empty map (no error, Get returns "").
+func TestProviderStore_GetOnEmptyFile(t *testing.T) {
+	store := OpenProviderStore(filepath.Join(t.TempDir(), "providers.json"))
+
+	got, err := store.Get("gcr.io")
+	if err != nil {
+		t.Fatalf("Get on empty store: unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("Get on empty store: got %q, want empty string", got)
+	}
+}
+
+// TestProviderStore_SetGetRoundTrip verifies that Set creates the file
+// and Get reads it back.
+func TestProviderStore_SetGetRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "providers.json")
+	store := OpenProviderStore(path)
+
+	if err := store.Set("gcr.io", "gcp"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	// Re-open from disk to confirm persistence.
+	reopened := OpenProviderStore(path)
+	got, err := reopened.Get("gcr.io")
+	if err != nil {
+		t.Fatalf("Get after reopen: %v", err)
+	}
+	if got != "gcp" {
+		t.Fatalf("Get after reopen: got %q, want \"gcp\"", got)
+	}
+}
+
+// TestProviderStore_SetIsIdempotent verifies that calling Set with the
+// same value twice does not error and leaves the file unchanged.
+func TestProviderStore_SetIsIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "providers.json")
+	store := OpenProviderStore(path)
+
+	if err := store.Set("gcr.io", "gcp"); err != nil {
+		t.Fatalf("first Set: %v", err)
+	}
+	if err := store.Set("gcr.io", "gcp"); err != nil {
+		t.Fatalf("second Set: %v", err)
+	}
+	got, _ := store.Get("gcr.io")
+	if got != "gcp" {
+		t.Fatalf("Get after idempotent Set: got %q, want \"gcp\"", got)
+	}
+}
+
+// TestProviderStore_SetOverwritesDifferentProvider covers the case
+// where a user logs in to the same host with two different providers
+// (e.g. switching from "basic" to "gcp"). The latest call wins.
+func TestProviderStore_SetOverwritesDifferentProvider(t *testing.T) {
+	store := OpenProviderStore(filepath.Join(t.TempDir(), "providers.json"))
+
+	if err := store.Set("gcr.io", "basic"); err != nil {
+		t.Fatalf("Set basic: %v", err)
+	}
+	if err := store.Set("gcr.io", "gcp"); err != nil {
+		t.Fatalf("Set gcp: %v", err)
+	}
+	got, _ := store.Get("gcr.io")
+	if got != "gcp" {
+		t.Fatalf("Get after overwrite: got %q, want \"gcp\"", got)
+	}
+}
+
+// TestProviderStore_DeleteMissing verifies that Delete on a host not in
+// the store is a no-op and not an error.
+func TestProviderStore_DeleteMissing(t *testing.T) {
+	store := OpenProviderStore(filepath.Join(t.TempDir(), "providers.json"))
+
+	if err := store.Delete("gcr.io"); err != nil {
+		t.Fatalf("Delete missing: %v", err)
+	}
+}
+
+// TestProviderStore_DeleteRoundTrip verifies that Delete removes the
+// entry and a subsequent Get returns "".
+func TestProviderStore_DeleteRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "providers.json")
+	store := OpenProviderStore(path)
+
+	if err := store.Set("gcr.io", "gcp"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := store.Delete("gcr.io"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	reopened := OpenProviderStore(path)
+	got, err := reopened.Get("gcr.io")
+	if err != nil {
+		t.Fatalf("Get after Delete+reopen: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("Get after Delete: got %q, want empty string", got)
+	}
+}
+
+// TestProviderStore_MalformedFile verifies that a sidecar with bad JSON
+// produces a parse error on Get, not silent corruption.
+func TestProviderStore_MalformedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "providers.json")
+	if err := os.WriteFile(path, []byte("not json"), 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	store := OpenProviderStore(path)
+	_, err := store.Get("gcr.io")
+	if err == nil {
+		t.Fatalf("expected error from malformed sidecar, got nil")
+	}
+}
+
+// TestProviderStore_WrongVersion verifies that an unknown version is
+// rejected (forward-compat guardrail).
+func TestProviderStore_WrongVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "providers.json")
+	if err := os.WriteFile(path, []byte(`{"version":999,"providers":{}}`), 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	store := OpenProviderStore(path)
+	_, err := store.Get("gcr.io")
+	if err == nil {
+		t.Fatalf("expected error from unknown version, got nil")
+	}
+}
+
+// TestProviderStore_ConcurrentAccess verifies that the store is safe
+// for use from multiple goroutines. Run with `go test -race` to catch
+// any data races.
+func TestProviderStore_ConcurrentAccess(t *testing.T) {
+	store := OpenProviderStore(filepath.Join(t.TempDir(), "providers.json"))
+
+	const goroutines = 8
+	const perGoroutine = 50
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				host := "host-" + string(rune('a'+(i+j)%4))
+				if err := store.Set(host, "gcp"); err != nil {
+					t.Errorf("Set(%q): %v", host, err)
+					return
+				}
+				if _, err := store.Get(host); err != nil && !errors.Is(err, fs.ErrNotExist) {
+					t.Errorf("Get(%q): %v", host, err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/checker/checker.go
+++ b/pkg/checker/checker.go
@@ -230,13 +230,13 @@ func (sc *SumChecker) fetchOciManifest(dep pkg.Dependency) (ocispec.Manifest, er
 // FetchOciManifestIntoJsonStr fetches the OCI manifest and returns it as a JSON string.
 func (sc *SumChecker) FetchOciManifestIntoJsonStr(opts opt.OciFetchOptions) (string, error) {
 	repoPath := utils.JoinPath(opts.Reg, opts.Repo)
-	cred, err := sc.GetCredentials(opts.Reg)
+	credFunc, err := sc.GetCredentialFunc()
 	if err != nil {
 		return "", err
 	}
 
 	ociCli, err := oci.NewOciClientWithOpts(
-		oci.WithCredential(cred),
+		oci.WithCredentialFunc(credFunc),
 		oci.WithRepoPath(repoPath),
 		oci.WithSettings(&sc.settings),
 	)
@@ -264,6 +264,19 @@ func (sc *SumChecker) GetCredentials(hostName string) (*remoteauth.Credential, e
 	}
 
 	return creds, nil
+}
+
+// GetCredentialFunc returns a dynamic [remoteauth.CredentialFunc] that
+// consults the kpm provider sidecar first and falls back to the ORAS
+// credential store. Use this instead of GetCredentials when the OCI
+// client should refresh short-lived provider-minted tokens (e.g. GCP
+// Workload Identity) on every 401.
+func (sc *SumChecker) GetCredentialFunc() (remoteauth.CredentialFunc, error) {
+	credStore, err := downloader.LoadCredentialFile(sc.settings.CredentialsFile)
+	if err != nil {
+		return nil, err
+	}
+	return credStore.Resolver(), nil
 }
 
 // extractChecksumFromManifest extracts the checksum from the OCI manifest.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -107,6 +107,19 @@ func (c *KpmClient) GetCredentials(hostName string) (*remoteauth.Credential, err
 	return creds, nil
 }
 
+// CredentialFunc returns a dynamic [remoteauth.CredentialFunc] that
+// consults the kpm provider sidecar first and falls back to the ORAS
+// credential store. Use this when building OCI clients that may need
+// to refresh short-lived provider-minted tokens (e.g. GCP Workload
+// Identity) on every 401.
+func (c *KpmClient) CredentialFunc() (remoteauth.CredentialFunc, error) {
+	credStore, err := c.GetCredsClient()
+	if err != nil {
+		return nil, err
+	}
+	return credStore.Resolver(), nil
+}
+
 // GetNoSumCheck will return the 'noSumCheck' flag.
 func (c *KpmClient) GetNoSumCheck() bool {
 	return c.noSumCheck

--- a/pkg/client/push.go
+++ b/pkg/client/push.go
@@ -195,13 +195,13 @@ func (c *KpmClient) Push(opts ...PushOption) error {
 // PushToOci will push a kcl package to oci registry.
 func (c *KpmClient) pushToOci(localPath string, ociOpts *opt.OciOptions, pushOpts *PushOptions) error {
 	repoPath := utils.JoinPath(ociOpts.Reg, ociOpts.Repo, ociOpts.Ref)
-	cred, err := c.GetCredentials(ociOpts.Reg)
+	credFunc, err := c.CredentialFunc()
 	if err != nil {
 		return err
 	}
 
 	ociCli, err := oci.NewOciClientWithOpts(
-		oci.WithCredential(cred),
+		oci.WithCredentialFunc(credFunc),
 		oci.WithRepoPath(repoPath),
 		oci.WithSettings(c.GetSettings()),
 		oci.WithInsecureSkipTLSverify(c.insecureSkipTLSverify),

--- a/pkg/cmd/cmd_login.go
+++ b/pkg/cmd/cmd_login.go
@@ -7,6 +7,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
 	"github.com/urfave/cli/v2"
 	"kcl-lang.io/kpm/pkg/auth"
@@ -90,10 +91,48 @@ func NewLoginCmd(kpmcli *client.KpmClient) *cli.Command {
 			if err != nil {
 				return err
 			}
+
+			// For non-basic providers, also record the host → provider
+			// mapping in the sidecar so subsequent pulls know to mint
+			// fresh credentials (the ORAS credential store only sees the
+			// first token, which expires after ~1h for GCP).
+			if providerName != "basic" && providerName != "" {
+				store, storeErr := openProviderStoreFor(kpmcli)
+				if storeErr != nil {
+					return reporter.NewErrorEvent(
+						reporter.FailedLogin,
+						storeErr,
+						fmt.Sprintf("failed to record provider mapping for '%s'", registry),
+					)
+				}
+				if setErr := store.Set(registry, providerName); setErr != nil {
+					return reporter.NewErrorEvent(
+						reporter.FailedLogin,
+						setErr,
+						fmt.Sprintf("failed to record provider mapping for '%s'", registry),
+					)
+				}
+			}
+
 			reporter.ReportMsgTo("Login Succeeded", kpmcli.GetLogWriter())
 			return nil
 		},
 	}
+}
+
+// openProviderStoreFor returns a ProviderStore rooted at the kpm
+// settings directory. Used by login (writer) and logout (reader).
+// We derive the path from settings so it always lives next to
+// config.json regardless of how the kpm client was constructed.
+func openProviderStoreFor(kpmcli *client.KpmClient) (*auth.ProviderStore, error) {
+	// Settings.CredentialsFile is "<home>/.kpm/config/config.json".
+	// The provider sidecar lives next to it as "providers.json".
+	credPath := kpmcli.GetSettings().CredentialsFile
+	if credPath == "" {
+		return nil, fmt.Errorf("kpm settings have no CredentialsFile; cannot locate provider sidecar")
+	}
+	sidecarPath := filepath.Join(filepath.Dir(credPath), "providers.json")
+	return auth.OpenProviderStore(sidecarPath), nil
 }
 
 // resolveCredentials resolves the (username, password) pair from CLI

--- a/pkg/cmd/cmd_logout.go
+++ b/pkg/cmd/cmd_logout.go
@@ -25,9 +25,26 @@ func NewLogoutCmd(kpmcli *client.KpmClient) *cli.Command {
 					fmt.Errorf("registry must be specified"),
 				)
 			}
-			err := kpmcli.LogoutOci(c.Args().First())
+			hostname := c.Args().First()
+			err := kpmcli.LogoutOci(hostname)
 			if err != nil {
 				return err
+			}
+			// Also drop any provider mapping for this host so future
+			// pulls don't keep minting credentials via the provider
+			// after the user logged out. This is a no-op when the
+			// host wasn't registered with a non-basic provider.
+			store, storeErr := openProviderStoreFor(kpmcli)
+			if storeErr == nil {
+				if delErr := store.Delete(hostname); delErr != nil {
+					// Surface but don't fail the whole logout — the
+					// ORAS credentials are already gone, which is
+					// what the user asked for.
+					reporter.ReportMsgTo(
+						fmt.Sprintf("warning: failed to clear provider mapping for '%s': %v", hostname, delErr),
+						kpmcli.GetLogWriter(),
+					)
+				}
 			}
 			reporter.ReportMsgTo("Logout Succeeded", kpmcli.GetLogWriter())
 			return nil

--- a/pkg/downloader/credential.go
+++ b/pkg/downloader/credential.go
@@ -3,19 +3,25 @@ package downloader
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/credentials"
+
+	kpmauth "kcl-lang.io/kpm/pkg/auth"
 )
 
 // CredStore is the store to get the credentials.
 type CredStore struct {
-	store credentials.Store
+	store        credentials.Store
+	credFilePath string
 }
 
 // LoadCredentialFile loads the credential file and return the CredStore.
-func LoadCredentialFile(filepath string) (*CredStore, error) {
-	store, err := credentials.NewStore(filepath, credentials.StoreOptions{})
+// credFilePath is the path to the ORAS credential file; the provider
+// sidecar lives next to it as "providers.json".
+func LoadCredentialFile(credFilePath string) (*CredStore, error) {
+	store, err := credentials.NewStore(credFilePath, credentials.StoreOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -26,7 +32,8 @@ func LoadCredentialFile(filepath string) (*CredStore, error) {
 	}
 
 	return &CredStore{
-		store: credentials.NewStoreWithFallbacks(store, dockerStore),
+		store:        credentials.NewStoreWithFallbacks(store, dockerStore),
+		credFilePath: credFilePath,
 	}, nil
 }
 
@@ -45,4 +52,16 @@ func (cred *CredStore) Credential(hostName string) (*auth.Credential, error) {
 		return nil, err
 	}
 	return &credential, nil
+}
+
+// Resolver returns an [auth.CredentialFunc] that consults the kpm
+// provider sidecar first and falls back to the underlying ORAS store.
+// It is the CredentialFunc ORAS should use when calling the OCI
+// client: providers like GCP Workload Identity return short-lived
+// (~1h) tokens, and ORAS re-enters this function on every 401, which
+// is exactly when we want to mint a fresh token.
+func (cred *CredStore) Resolver() auth.CredentialFunc {
+	sidecar := kpmauth.OpenProviderStore(filepath.Join(filepath.Dir(cred.credFilePath), "providers.json"))
+	r := kpmauth.NewResolver(sidecar, cred.store)
+	return r.Resolve
 }

--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -249,22 +249,17 @@ func (d *OciDownloader) LatestVersion(opts *DownloadOptions) (string, error) {
 
 	repoPath := utils.JoinPath(ociSource.Reg, ociSource.Repo)
 
-	var cred *remoteauth.Credential
-	var err error
-	if opts.credsStore != nil {
-		cred, err = opts.credsStore.Credential(ociSource.Reg)
-		if err != nil {
-			return "", err
-		}
-	} else {
-		cred = &remoteauth.Credential{}
+	credOpt, err := credentialOptionFor(opts.credsStore, ociSource.Reg)
+	if err != nil {
+		return "", err
 	}
 
 	ociCli, err := oci.NewOciClientWithOpts(
-		oci.WithCredential(cred),
-		oci.WithRepoPath(repoPath),
-		oci.WithSettings(&opts.Settings),
-		oci.WithInsecureSkipTLSverify(opts.InsecureSkipTLSverify),
+		append([]oci.OciClientOption{
+			oci.WithRepoPath(repoPath),
+			oci.WithSettings(&opts.Settings),
+			oci.WithInsecureSkipTLSverify(opts.InsecureSkipTLSverify),
+		}, credOpt)...,
 	)
 
 	if err != nil {
@@ -403,22 +398,17 @@ func (d *OciDownloader) Download(opts *DownloadOptions) error {
 
 	repoPath := utils.JoinPath(ociSource.Reg, ociSource.Repo)
 
-	var cred *remoteauth.Credential
-	var err error
-	if opts.credsStore != nil {
-		cred, err = opts.credsStore.Credential(ociSource.Reg)
-		if err != nil {
-			return err
-		}
-	} else {
-		cred = &remoteauth.Credential{}
+	credOpt, err := credentialOptionFor(opts.credsStore, ociSource.Reg)
+	if err != nil {
+		return err
 	}
 
 	ociCli, err := oci.NewOciClientWithOpts(
-		oci.WithCredential(cred),
-		oci.WithRepoPath(repoPath),
-		oci.WithSettings(&opts.Settings),
-		oci.WithInsecureSkipTLSverify(opts.InsecureSkipTLSverify),
+		append([]oci.OciClientOption{
+			oci.WithRepoPath(repoPath),
+			oci.WithSettings(&opts.Settings),
+			oci.WithInsecureSkipTLSverify(opts.InsecureSkipTLSverify),
+		}, credOpt)...,
 	)
 
 	if err != nil {
@@ -706,3 +696,23 @@ func (d *GitDownloader) Download(opts *DownloadOptions) error {
 }
 
 var ErrNotFoundAndOffline = errors.New("not found and offline")
+
+// credentialOptionFor picks the right oci.OciClientOption for a single
+// OCI client. When credsStore is nil we install an empty static
+// credential (anonymous access). When credsStore is set we install
+// the dynamic Resolver so provider-minted tokens can refresh on every
+// 401 — the mechanism behind GCP Workload Identity pull-side refresh.
+//
+// An empty hostName is reported as an error (matching the previous
+// behaviour of CredStore.Credential). Letting an empty host through
+// produces confusing DNS-level errors downstream.
+func credentialOptionFor(credsStore *CredStore, hostName string) (oci.OciClientOption, error) {
+	if hostName == "" {
+		return nil, fmt.Errorf("hostName is empty")
+	}
+	if credsStore == nil {
+		// ORAS treats an empty credential as anonymous access.
+		return oci.WithCredential(&remoteauth.Credential{}), nil
+	}
+	return oci.WithCredentialFunc(credsStore.Resolver()), nil
+}

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -66,6 +66,7 @@ type OciClient struct {
 	isPlainHttp           *bool
 	insecureSkipTLSverify bool
 	cred                  *remoteauth.Credential
+	credFunc              remoteauth.CredentialFunc
 	PullOciOptions        *PullOciOptions
 }
 
@@ -100,10 +101,27 @@ func WithRepoPath(repoPath string) OciClientOption {
 	}
 }
 
-// WithCredential sets the credential of the OciClient
+// WithCredential sets a static credential on the OciClient. It is
+// retained for backwards compatibility — callers that need per-host
+// resolution (e.g. to refresh short-lived GCP tokens) should use
+// WithCredentialFunc instead. If both are passed, WithCredentialFunc
+// wins.
 func WithCredential(credential *remoteauth.Credential) OciClientOption {
 	return func(c *OciClient) error {
 		c.cred = credential
+		return nil
+	}
+}
+
+// WithCredentialFunc sets a dynamic credential resolver. ORAS calls
+// this on every 401 retry, so providers like GCPProvider can mint a
+// fresh token each time the previous one expires (~1h for Workload
+// Identity federated tokens).
+//
+// When this option is supplied it takes precedence over WithCredential.
+func WithCredentialFunc(fn remoteauth.CredentialFunc) OciClientOption {
+	return func(c *OciClient) error {
+		c.credFunc = fn
 		return nil
 	}
 }
@@ -161,10 +179,16 @@ func NewOciClientWithOpts(opts ...OciClientOption) (*OciClient, error) {
 	}
 
 	ctx := context.Background()
+	credFunc := client.credFunc
+	if credFunc == nil && client.cred != nil {
+		// Backwards compatibility: callers using WithCredential still
+		// get a static credential for the configured host.
+		credFunc = remoteauth.StaticCredential(client.repo.Reference.Host(), *client.cred)
+	}
 	client.repo.Client = &remoteauth.Client{
 		Client:     customClient,
 		Cache:      newAuthCache(client.settings),
-		Credential: remoteauth.StaticCredential(client.repo.Reference.Host(), *client.cred),
+		Credential: credFunc,
 	}
 
 	// If the plain http is not specified


### PR DESCRIPTION
## Summary

Continues the GCP Workload Identity work from #766. PR #766 added
`kpm login --provider=gcp` which writes a short-lived OAuth token
to the ORAS credential store. Subsequent pulls then see that
cached token directly with no way to know it came from GCP, so they
fail silently after ~1h when the token expires.

This PR wires the OCI client through a dynamic
`remoteauth.CredentialFunc` that ORAS re-enters on every 401. A
new sidecar `providers.json` maps `host -> provider` so a
follow-up `kpm pull` knows to mint a fresh credential via the
matching `auth.Provider` instead of reading the stale ORAS-stored
token.

## Why a sidecar, not extending `config.json`

ORAS owns `config.json` and would happily overwrite any extra
fields it does not understand. The sidecar keeps provider
ownership in a file kpm controls, so future migrations (AWS,
Azure, etc.) only touch kpm code.

## Changes

- **`pkg/auth/store.go`** (new) — small JSON sidecar store with
  atomic writes (temp + rename), lazy load, and `sync.RWMutex`
  concurrency.
- **`pkg/auth/resolve.go`** (new) — `Resolver` that consults
  `ProviderStore` first and falls back to the ORAS
  `credentials.Store`.
- **`pkg/oci/oci.go`** — new `WithCredentialFunc` option;
  `WithCredential` preserved for backwards compatibility
  (`CredentialFunc` wins if both are passed).
- **`pkg/downloader/credential.go`** — `CredStore.Resolver()`
  exposes the sidecar + fallback chain as an
  `auth.CredentialFunc`.
- **`pkg/downloader/downloader.go`** — both OCI client call sites
  now use `credentialOptionFor(...)` which returns the right
  option based on whether `credsStore` is set, and rejects empty
  `hostName` (matching the previous behaviour of
  `CredStore.Credential`).
- **`pkg/checker/checker.go`** — `SumChecker.GetCredentialFunc()`
  so the manifest fetch uses dynamic resolution.
- **`pkg/client/{client,push}.go`** — `KpmClient.CredentialFunc()`
  so push uses dynamic resolution too.
- **`pkg/cmd/cmd_login.go`** — after a non-basic login, record
  `host -> providerName` in the sidecar so subsequent pulls know
  which provider to invoke.
- **`pkg/cmd/cmd_logout.go`** — best-effort: also drop the host
  from the sidecar so post-logout pulls fall back to anonymous /
  static credentials.

## Tests

- **`pkg/auth/store_test.go`** — 9 cases: round-trip, idempotent
  `Set`, `Delete` missing, malformed file, wrong version,
  concurrent `Set`, etc.
- **`pkg/auth/resolve_test.go`** — 7 cases using a fake GCE
  metadata server via `httptest.NewServer` + `GCE_METADATA_HOST`,
  covering nil-safe, no-provider, provider-routed,
  per-invocation mint, provider errors, unknown provider, and
  fallback missing.

## Verification (local)

```
go build ./...                          # pass
go vet ./...                            # clean
gofmt -l pkg/auth pkg/cmd ...           # clean
go test ./pkg/auth/... -race            # pass (16 tests)
go test ./pkg/cmd/... -race             # pass
go test ./pkg/downloader/... -race      # pass
```

`TestModCheckerCheck_WithTrustedSum` and `TestPull` fail on this
machine but reproduce on plain `origin/main` without these
changes — pre-existing environmental issues (kpm CLI not on PATH
in test, and ghcr.io HTTP/2 PROTOCOL_ERROR respectively).

## Out of scope (follow-ups)

- AWS / Azure providers — the `Provider` interface is designed
  for them to slot in.
- function-kcl wiring — add a `--provider` flag (or CRD field)
  on `KCLInput.Spec.Credentials`.
- Auto-detect cloud from the metadata server.

Refs: PR #766, function-kcl #251.