### PR TITLE
fix(auth): allow plaintext credential storage on headless CI

### DIFF
--- a/pkg/client/login.go
+++ b/pkg/client/login.go
@@ -12,16 +12,7 @@ import (
 
 // LoginOci will login to the oci registry.
 func (c *KpmClient) LoginOci(hostname, username, password string) error {
-	// Allow plaintext credentials for plain HTTP registries
-	defaultOciPlainHttp, forceOciPlainHttp := c.GetSettings().ForceOciPlainHttp()
-	allowPlaintext := false
-	if defaultOciPlainHttp || forceOciPlainHttp {
-		allowPlaintext = true
-	}
-
-	store, err := credentials.NewStore(c.GetSettings().CredentialsFile, credentials.StoreOptions{
-		AllowPlaintextPut: allowPlaintext,
-	})
+	store, err := c.credentialStore()
 	if err != nil {
 		return err
 	}
@@ -36,7 +27,8 @@ func (c *KpmClient) LoginOci(hostname, username, password string) error {
 		return err
 	}
 
-	// Handle plain HTTP setting
+	// The plain HTTP setting only controls the transport.
+	defaultOciPlainHttp, forceOciPlainHttp := c.GetSettings().ForceOciPlainHttp()
 	if defaultOciPlainHttp || forceOciPlainHttp {
 		registry.PlainHTTP = true
 	}
@@ -57,4 +49,23 @@ func (c *KpmClient) LoginOci(hostname, username, password string) error {
 	}
 
 	return nil
+}
+
+// credentialStore returns the store used to persist registry credentials.
+//
+// Plaintext storage is always allowed: when the config file configures a
+// credential helper (credsStore/credHelpers), oras-go delegates to it and
+// plaintext is never touched; when no helper is available — the usual case
+// on headless CI runners — the config file is the only backend, and
+// refusing it makes `login` fail against every HTTPS registry with
+// "putting plaintext credentials is disabled". This matches `docker login`,
+// which writes a plaintext `auths` entry when no credsStore is set.
+//
+// Transport security is independent of the storage policy and remains
+// governed by the plain HTTP settings.
+// See https://github.com/kcl-lang/kpm/issues/769.
+func (c *KpmClient) credentialStore() (*credentials.DynamicStore, error) {
+	return credentials.NewStore(c.GetSettings().CredentialsFile, credentials.StoreOptions{
+		AllowPlaintextPut: true,
+	})
 }

--- a/pkg/client/login_test.go
+++ b/pkg/client/login_test.go
@@ -1,12 +1,16 @@
 package client
 
 import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"kcl-lang.io/kpm/pkg/mock"
-	"os"
+	"oras.land/oras-go/v2/registry/remote/auth"
 )
 
 func TestLogin(t *testing.T) {
@@ -31,4 +35,37 @@ func TestLogin(t *testing.T) {
 	assert.Equal(t, err, nil)
 	err = kpmcli.LoginOci("172.88.0.8:5002", "test", "1234")
 	assert.Equal(t, err, nil)
+}
+
+// TestLoginCredentialStorePlaintext reproduces the headless-CI scenario
+// from https://github.com/kcl-lang/kpm/issues/769: with no credential
+// helper configured and without OCI_REG_PLAIN_HTTP, login must still be
+// able to persist credentials into the config file instead of failing
+// with "putting plaintext credentials is disabled".
+func TestLoginCredentialStorePlaintext(t *testing.T) {
+	credFile := filepath.Join(t.TempDir(), "config.json")
+	kpmcli := &KpmClient{}
+	kpmcli.settings.CredentialsFile = credFile
+
+	store, err := kpmcli.credentialStore()
+	assert.Equal(t, nil, err)
+
+	want := auth.Credential{Username: "user", Password: "token"}
+	assert.Equal(t, nil, store.Put(context.Background(), "ghcr.io", want))
+
+	got, err := store.Get(context.Background(), "ghcr.io")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, want, got)
+
+	// The credential is persisted as a plaintext `auths` entry, exactly
+	// like `docker login` does without a credsStore.
+	data, err := os.ReadFile(credFile)
+	assert.Equal(t, nil, err)
+	var cfg struct {
+		Auths map[string]struct {
+			Auth string `json:"auth"`
+		} `json:"auths"`
+	}
+	assert.Equal(t, nil, json.Unmarshal(data, &cfg))
+	assert.Contains(t, cfg.Auths, "ghcr.io")
 }


### PR DESCRIPTION
Fixes #769

## Summary

`LoginOci` only enabled `AllowPlaintextPut` when plain-HTTP mode was on, conflating two independent concerns:

- **transport** security (plain HTTP vs HTTPS)
- **credential storage** policy (plaintext file vs helper)

On a headless CI runner there is no credential helper, so the ORAS file store refused to persist credentials (`putting plaintext credentials is disabled`) unless `OCI_REG_PLAIN_HTTP=on` was set — a flag that also forces `registry.PlainHTTP = true` and therefore cannot work against HTTPS-only registries such as ghcr.io. Login was impossible on CI for the public registries (kcl-lang/modules had to hand-write `auths` entries into `config.json`: kcl-lang/modules#397, #403).

This implements option 1 from the issue — **docker CLI semantics**:

- `AllowPlaintextPut` is now always set. When the config file configures `credsStore`/`credHelpers`, oras-go delegates to the helper and plaintext is never touched; when no helper exists, the config file is the only backend and refusing it breaks login. This is exactly what `docker login` does without a `credsStore`.
- Plain HTTP settings continue to govern only the transport (`registry.PlainHTTP`).

## Test plan

- [x] New `TestLoginCredentialStorePlaintext` persists a credential through the store built by `LoginOci` with a fresh (helper-less) config file and asserts it reads back and lands as a plaintext `auths` entry. Verified it fails with the exact error from the issue (`putting plaintext credentials is disabled`) when the flag is flipped back off
- [x] `go test ./pkg/auth/ ./pkg/settings/ ./pkg/cmd -run 'TestLogin|TestLogout'` pass; full registry-dependent suite left to CI (needs Docker, unavailable locally)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)