### PR TITLE
fix(login): allow storing credentials without OCI_REG_PLAIN_HTTP (fixes #769)

### DIFF
--- a/pkg/client/login.go
+++ b/pkg/client/login.go
@@ -12,16 +12,9 @@ import (
 
 // LoginOci will login to the oci registry.
 func (c *KpmClient) LoginOci(hostname, username, password string) error {
-	// Allow plaintext credentials for plain HTTP registries
 	defaultOciPlainHttp, forceOciPlainHttp := c.GetSettings().ForceOciPlainHttp()
-	allowPlaintext := false
-	if defaultOciPlainHttp || forceOciPlainHttp {
-		allowPlaintext = true
-	}
 
-	store, err := credentials.NewStore(c.GetSettings().CredentialsFile, credentials.StoreOptions{
-		AllowPlaintextPut: allowPlaintext,
-	})
+	store, err := c.credentialStore()
 	if err != nil {
 		return err
 	}
@@ -57,4 +50,23 @@ func (c *KpmClient) LoginOci(hostname, username, password string) error {
 	}
 
 	return nil
+}
+
+// credentialStore returns the ORAS credential store that LoginOci
+// persists credentials through.
+//
+// AllowPlaintextPut is enabled unconditionally. In ORAS the plain-text
+// config file is only the last-resort backend: server-specific
+// credential helpers (credHelpers) and the credentials store (credsStore)
+// always take precedence, and the flag merely allows the fallback when no
+// helper is configured — the same behaviour as the Docker and ORAS CLIs.
+// Gating it on the plain-HTTP setting made `kpm registry login` fail
+// with "putting plaintext credentials is disabled" on headless CI
+// runners (no keyring) against HTTPS-only registries such as ghcr.io and
+// docker.io, because that flag also forces plain-HTTP transport.
+// See #769.
+func (c *KpmClient) credentialStore() (credentials.Store, error) {
+	return credentials.NewStore(c.GetSettings().CredentialsFile, credentials.StoreOptions{
+		AllowPlaintextPut: true,
+	})
 }

--- a/pkg/client/login_test.go
+++ b/pkg/client/login_test.go
@@ -1,12 +1,16 @@
 package client
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"kcl-lang.io/kpm/pkg/mock"
-	"os"
+	"kcl-lang.io/kpm/pkg/settings"
+	remoteauth "oras.land/oras-go/v2/registry/remote/auth"
 )
 
 func TestLogin(t *testing.T) {
@@ -31,4 +35,47 @@ func TestLogin(t *testing.T) {
 	assert.Equal(t, err, nil)
 	err = kpmcli.LoginOci("172.88.0.8:5002", "test", "1234")
 	assert.Equal(t, err, nil)
+}
+
+// Regression test for #769: storing login credentials must work with the
+// default HTTPS transport (plain HTTP off). Previously the credential
+// store only allowed plaintext puts when OCI_REG_PLAIN_HTTP was on,
+// which made `kpm registry login` fail with "putting plaintext
+// credentials is disabled" on headless CI runners without a credential
+// helper, against HTTPS-only registries such as ghcr.io and docker.io.
+func TestLoginOciStoresCredentialsWithoutPlainHttp(t *testing.T) {
+	tmpDir := t.TempDir()
+	credFile := filepath.Join(tmpDir, "config.json")
+
+	// Seed an existing auths entry so ORAS does not auto-detect a
+	// platform credential helper (which would depend on the host
+	// machine's setup and make the test non-deterministic).
+	seed := `{"auths":{"registry.example.com":{"auth":"dXNlcjpwYXNz"}}}`
+	assert.NoError(t, os.WriteFile(credFile, []byte(seed), 0o600))
+
+	kpmcli := &KpmClient{
+		settings: settings.Settings{CredentialsFile: credFile},
+	}
+
+	// The default: HTTPS transport, no forced plain HTTP.
+	def, forced := kpmcli.GetSettings().ForceOciPlainHttp()
+	assert.False(t, def)
+	assert.False(t, forced)
+
+	store, err := kpmcli.credentialStore()
+	assert.NoError(t, err)
+
+	// Before the fix this failed with ErrPlaintextPutDisabled.
+	err = store.Put(context.Background(), "ghcr.io", remoteauth.Credential{
+		Username: "user",
+		Password: "token",
+	})
+	assert.NoError(t, err)
+
+	// The credential is persisted and read back from the plain-text
+	// config file.
+	cred, err := store.Get(context.Background(), "ghcr.io")
+	assert.NoError(t, err)
+	assert.Equal(t, "user", cred.Username)
+	assert.Equal(t, "token", cred.Password)
 }


### PR DESCRIPTION
## Summary

Fixes #769. `LoginOci` gated ORAS's `AllowPlaintextPut` behind the plain-HTTP setting, so on a headless CI runner (no credential helper) the ORAS store refused to persist credentials at all and `kpm registry login` failed with:

```
failed to store the credentials for ghcr.io: putting plaintext credentials is disabled
```

against HTTPS-only registries — the only way to enable the flag, `OCI_REG_PLAIN_HTTP=on`, also forces plain-HTTP transport.

The store now always passes `AllowPlaintextPut: true` (construction extracted into `credentialStore()`), matching the Docker and ORAS CLIs. This does not weaken helper-based setups: in ORAS's `DynamicStore` the plain-text config file is the **last-resort** backend — server-specific helpers (`credHelpers`) and `credsStore` always take precedence — the flag only permits the fallback when no helper is configured. Precedent: the ORAS CLI itself passes `AllowPlaintextPut: true` unconditionally (`internal/credential/store.go`).

## Test plan

- [x] New regression test `TestLoginOciStoresCredentialsWithoutPlainHttp`: with plain HTTP off (HTTPS transport, the default), a `Put` into the store succeeds and the credential is readable back. The credentials file is pre-seeded with an `auths` entry so ORAS's platform-helper auto-detection cannot make the test machine-dependent.
- [x] Verified the test fails on the old gating logic and passes with the fix (simulated both locally).
- [x] `go build ./...`, `go vet ./pkg/client/` clean; all `pkg/cmd` login tests pass.
- [ ] `pkg/client` `TestLogin` (docker-registry based) needs a running Docker daemon; unchanged code path (`OCI_REG_PLAIN_HTTP=on` behaves identically before/after) — covered by CI.

 downstream context: kcl-lang/modules#395, kcl-lang/modules#403, kcl-lang/modules#378.

🤖 Generated with [Claude Code](https://claude.com/claude-code)